### PR TITLE
fix: remove shadow of section cards, closes #44

### DIFF
--- a/web/src/components/WeeklyCalendar.tsx
+++ b/web/src/components/WeeklyCalendar.tsx
@@ -831,10 +831,10 @@ function UnscheduledSectionsCard({
                     key={`${item.enrollment.courseId}_${item.section.id}_${index}`}
                     className={`
                       ${item.enrollment.color || 'bg-indigo-500'}
-                      rounded-sm text-xs text-white shadow-md
+                      rounded-sm text-xs text-white
                       hover:scale-105 transition-all cursor-pointer
                       overflow-hidden group relative
-                      ${isSelected ? 'scale-105 shadow-2xl' : ''}
+                      ${isSelected ? 'scale-105' : ''}
                     `}
                     style={{
                       width: 'calc((100% - 32px) / 5)',


### PR DESCRIPTION
This is a temporary workaround for the weird gray shadow background on section cards when taking a screenshot on **Safari**

The shadow effect is actually not very obvious, so an effective but not radical solution would be just removing the shadow of all the cards.

<img width="2012" height="1997" alt="Image" src="https://github.com/user-attachments/assets/3ecb280d-53c2-4c68-8e50-99646210b80f" />