### PR TITLE
fix: include Chinese results in Google search

### DIFF
--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -1324,10 +1324,10 @@ function CourseCard({
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation()
-                    googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Outline OR 大綱`)
+                    googleSearchAndOpen(`CUHK ${course.subject}${course.courseCode} Outline OR 大綱`)
                   }}
                   className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
-                  title={`Search Google for "${course.subject} ${course.courseCode}" outline`}
+                  title={`Search Google for "${course.subject}${course.courseCode}" outline`}
                 >
                   <Search className="w-3 h-3" />
                   Outline
@@ -1337,10 +1337,10 @@ function CourseCard({
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation()
-                    googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Review OR 評價`)
+                    googleSearchAndOpen(`CUHK ${course.subject}${course.courseCode} Review OR 評價`)
                   }}
                   className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
-                  title={`Search Google for "${course.subject} ${course.courseCode}" reviews`}
+                  title={`Search Google for "${course.subject}${course.courseCode}" reviews`}
                 >
                   <Search className="w-3 h-3" />
                   Reviews
@@ -1515,10 +1515,10 @@ function CourseCard({
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation()
-                  googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Outline OR 大綱`)
+                  googleSearchAndOpen(`CUHK ${course.subject}${course.courseCode} Outline OR 大綱`)
                 }}
                 className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}" outline`}
+                title={`Search Google for "${course.subject}${course.courseCode}" outline`}
               >
                 <Search className="w-3 h-3" />
                 Outline
@@ -1528,10 +1528,10 @@ function CourseCard({
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation()
-                  googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Review OR 評價`)
+                  googleSearchAndOpen(`CUHK ${course.subject}${course.courseCode} Review OR 評價`)
                 }}
                 className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}" reviews`}
+                title={`Search Google for "${course.subject}${course.courseCode}" reviews`}
               >
                 <Search className="w-3 h-3" />
                 Reviews

--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -1324,13 +1324,26 @@ function CourseCard({
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation()
-                    googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode}`)
+                    googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Outline OR 大綱`)
                   }}
-                  className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[80px] flex-shrink-0"
-                  title={`Search Google for "CUHK ${course.subject} ${course.courseCode}"`}
+                  className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
+                  title={`Search Google for "${course.subject} ${course.courseCode}" outline`}
                 >
                   <Search className="w-3 h-3" />
-                  Google
+                  Outline
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Review OR 評價`)
+                  }}
+                  className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
+                  title={`Search Google for "${course.subject} ${course.courseCode}" reviews`}
+                >
+                  <Search className="w-3 h-3" />
+                  Reviews
                 </Button>
                 <Button
                   variant="ghost"

--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -1515,13 +1515,26 @@ function CourseCard({
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation()
-                  googleSearchAndOpen(`${course.subject} ${course.courseCode}`)
+                  googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Outline OR 大綱`)
                 }}
-                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[80px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}"`}
+                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
+                title={`Search Google for "${course.subject} ${course.courseCode}" outline`}
               >
                 <Search className="w-3 h-3" />
-                Google
+                Outline
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Review OR 評價`)
+                }}
+                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[65px] flex-shrink-0"
+                title={`Search Google for "${course.subject} ${course.courseCode}" reviews`}
+              >
+                <Search className="w-3 h-3" />
+                Reviews
               </Button>
               <Button
                 variant="ghost"

--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -1320,31 +1320,18 @@ function CourseCard({
               </CardTitle>
               <div className="flex flex-wrap items-center gap-1">
                 <Button
-                variant="ghost"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  googleSearchAndOpen(`CUHK ${course.subject}${course.courseCode} Outline OR Syllabus`)
-                }}
-                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[100px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}" outline`}
-              >
-                <Search className="w-3 h-3" />
-                Course Outline
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Reviews`)
-                }}
-                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[100px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}" reviews`}
-              >
-                <Search className="w-3 h-3" />
-                Course Reviews
-              </Button>
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode}`)
+                  }}
+                  className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[80px] flex-shrink-0"
+                  title={`Search Google for "CUHK ${course.subject} ${course.courseCode}"`}
+                >
+                  <Search className="w-3 h-3" />
+                  Google
+                </Button>
                 <Button
                   variant="ghost"
                   size="sm"
@@ -1515,26 +1502,13 @@ function CourseCard({
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation()
-                  googleSearchAndOpen(`CUHK ${course.subject}${course.courseCode} Outline OR Syllabus`)
+                  googleSearchAndOpen(`${course.subject} ${course.courseCode}`)
                 }}
-                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[100px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}" outline`}
+                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[80px] flex-shrink-0"
+                title={`Search Google for "${course.subject} ${course.courseCode}"`}
               >
                 <Search className="w-3 h-3" />
-                Course Outline
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  googleSearchAndOpen(`CUHK ${course.subject} ${course.courseCode} Reviews`)
-                }}
-                className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-200 min-w-[100px] flex-shrink-0"
-                title={`Search Google for "${course.subject} ${course.courseCode}" reviews`}
-              >
-                <Search className="w-3 h-3" />
-                Course Reviews
+                Google
               </Button>
               <Button
                 variant="ghost"


### PR DESCRIPTION
the suffices like "Outline", "Review" are still useful, but we may add Chinese alternatives as well.

Without those suffices, the results get too generic.

Moreover, combining the subject and the code, e.g. GEUC 2017  -> GEUC2017 also helps narrow down results