### PR TITLE
refactor: migrate to static export

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -30,8 +30,29 @@ Decision: host the app on Cloudflare Pages.
 
 Why it fits:
 
-- Cloudflare's static asset request and bandwidth model fits this app better
+- Cloudflare's static-asset request and bandwidth model suits a static frontend, with a generous free tier
 - deployment stays aligned with the frontend-only/static architecture
+
+Caveat (since resolved): this only holds once the site is a true static export. The original `@cloudflare/next-on-pages` setup routed every request through a Worker, so the ~400-file course-data fan-out was billed as Function requests — nearly the opposite of the static-asset model this rationale assumed. See [Static Export Over The next-on-pages Adapter](#static-export-over-the-next-on-pages-adapter).
+
+## Static Export Over The next-on-pages Adapter
+
+`@cloudflare/next-on-pages` (now deprecated) generated a worker-first `_routes.json` (`include: ["/*"]`, excluding only `/_next/static/*`), so nearly every request invoked the Worker. The ~400 `public/data/<year>/*.json` files eager-loaded each session were billed as Function requests, hitting ~78% of the 100k/day free limit during add-drop. Caching didn't help — the quota counts requests, not bytes, so even `304` revalidations were billed.
+
+Decision: migrate to static export (`output: 'export'`). Cloudflare then serves assets first, so HTML, data, and images are free; only the PostHog `/x8m2k/*` proxy stays a Function.
+
+Why it fits:
+
+- makes the [Cloudflare Pages rationale](#cloudflare-pages-over-vercel) true — the catalog is served as static assets, not billed Function requests
+- drops a deprecated dependency and the `legacy-peer-deps` workaround it required
+
+Invariant: never route the course catalog through a Function. A `middleware.ts`, a `rewrites()`/`headers()` rule on data paths, or a dashboard misconfig would silently re-bill it at ~10× cost while the app still works. [#178](https://github.com/EagleZhen/another-cuhk-course-planner/issues/178) tracks automated guards.
+
+Tradeoffs:
+
+- no SSR or middleware (fine — the app is frontend-only anyway)
+- `next/image` ships unoptimized (`images.unoptimized`) without a server
+- the proxy moved from a `next.config` rewrite to a Function (`web/functions/x8m2k/[[path]].ts`), kept single-host (assets-host split is [#177](https://github.com/EagleZhen/another-cuhk-course-planner/issues/177))
 
 ## PostHog Over Vercel Analytics
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,19 +4,19 @@ The web app is deployed at <https://another-cuhk-course-planner.com/>.
 
 ## Hosting
 
-The app is hosted on Cloudflare Pages.
-
-The app is mostly static after build, so Cloudflare Pages fits the workload well. See [decisions.md](decisions.md#cloudflare-pages-over-vercel) for the hosting rationale.
+The app is hosted on Cloudflare Pages as a static export (`output: 'export'` in [web/next.config.ts](../web/next.config.ts)): `npm run build` emits a static site to `web/out/`. Cloudflare build config (root `web`): build command `npm run build`, output directory `out`. Node is pinned via [web/.nvmrc](../web/.nvmrc); Cloudflare ignores `package.json`'s `engines` (see [decisions.md](decisions.md#pin-the-node-version-via-nvmrc)).
 
 The repository no longer keeps a `vercel.json` file or Vercel runtime packages.
 
-Cloudflare Pages builds with the Node.js version pinned in [web/.nvmrc](../web/.nvmrc) — it does not read `package.json`'s `engines` field. See [decisions.md](decisions.md#pin-the-node-version-via-nvmrc) for why this is pinned explicitly.
+### Serving and billing
+
+Cloudflare serves assets first — HTML, course JSON under [web/public/data/](../web/public/data/), and images are free static assets (edge-cached; even `304` revalidations cost nothing). Only the PostHog proxy at `/x8m2k/*` runs as a Pages Function, the sole path billed against the Functions limit (100k/day free) — so eager-loading ~400 course files per session is cheap. Keeping the catalog off the Function path is the point of the hosting choice; see [decisions.md](decisions.md#static-export-over-the-next-on-pages-adapter).
 
 ## Analytics
 
 Analytics use PostHog, initialized in `web/src/instrumentation-client.ts`.
 
-The app sends PostHog events through the `/x8m2k` rewrite configured in `web/next.config.ts`. Local development works without analytics when `NEXT_PUBLIC_POSTHOG_KEY` is unset.
+The app sends PostHog traffic to `/x8m2k`, a same-origin reverse proxy (so ad blockers don't recognize PostHog's domain) that runs as a Pages Function (`web/functions/x8m2k/[[path]].ts`) forwarding to `us.i.posthog.com`. Local development works without analytics when `NEXT_PUBLIC_POSTHOG_KEY` is unset.
 
 The entry pageview is captured manually, then `utm_*` params are stripped from the URL — so inbound links can be tagged (e.g. `?utm_source=dcard`) without the tag lingering in bookmarks or re-shares. Unhandled JS errors are auto-captured to Error Tracking.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,9 @@ The web app is deployed at <https://another-cuhk-course-planner.com/>.
 
 ## Hosting
 
-The app is hosted on Cloudflare Pages as a static export (`output: 'export'` in [web/next.config.ts](../web/next.config.ts)): `npm run build` emits a static site to `web/out/`. Cloudflare build config (root `web`): build command `npm run build`, output directory `out`. Node is pinned via [web/.nvmrc](../web/.nvmrc); Cloudflare ignores `package.json`'s `engines` (see [decisions.md](decisions.md#pin-the-node-version-via-nvmrc)).
+The app is hosted on Cloudflare Pages as a static export (`output: 'export'` in [web/next.config.ts](../web/next.config.ts)): `npm run build` emits a static site to `web/out/`.
+
+Config splits between [web/wrangler.jsonc](../web/wrangler.jsonc) — the source of truth for the output dir and the Functions runtime (compatibility date and flags) — and the Cloudflare dashboard, which owns only the build command (`npm run build`) and root directory (`web`), which Pages has no config-file field for. Node is pinned via [web/.nvmrc](../web/.nvmrc); Cloudflare ignores `package.json`'s `engines` (see [decisions.md](decisions.md#pin-the-node-version-via-nvmrc)).
 
 The repository no longer keeps a `vercel.json` file or Vercel runtime packages.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,7 +18,9 @@ Cloudflare serves assets first — HTML, course JSON under [web/public/data/](..
 
 Analytics use PostHog, initialized in `web/src/instrumentation-client.ts`.
 
-The app sends PostHog traffic to `/x8m2k`, a same-origin reverse proxy (so ad blockers don't recognize PostHog's domain) that runs as a Pages Function (`web/functions/x8m2k/[[path]].ts`) forwarding to `us.i.posthog.com`. Local development works without analytics when `NEXT_PUBLIC_POSTHOG_KEY` is unset.
+posthog-js sends everything to `/x8m2k` (its `api_host`) — a same-origin path, so ad blockers don't recognize PostHog's domain — and a catch-all Pages Function (`web/functions/x8m2k/[[path]].ts`) forwards it to PostHog's ingest host, `us.i.posthog.com`. The Function runs only at the edge (production or `wrangler pages dev`, not plain `npm run dev`) and is the app's only Function. Local dev works without analytics when `NEXT_PUBLIC_POSTHOG_KEY` is unset.
+
+Don't confuse that with `ui_host` (`us.posthog.com`): that's PostHog's separate dashboard host, referenced only so the SDK can link back to it. No events go there, so it isn't proxied.
 
 The entry pageview is captured manually, then `utm_*` params are stripped from the URL — so inbound links can be tagged (e.g. `?utm_source=dcard`) without the tag lingering in bookmarks or re-shares. Unhandled JS errors are auto-captured to Error Tracking.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ The repository no longer keeps a `vercel.json` file or Vercel runtime packages.
 
 ### Serving and billing
 
-Cloudflare serves assets first — HTML, course JSON under [web/public/data/](../web/public/data/), and images are free static assets (edge-cached; even `304` revalidations cost nothing). Only the PostHog proxy at `/x8m2k/*` runs as a Pages Function, the sole path billed against the Functions limit (100k/day free) — so eager-loading ~400 course files per session is cheap. Keeping the catalog off the Function path is the point of the hosting choice; see [decisions.md](decisions.md#static-export-over-the-next-on-pages-adapter).
+Cloudflare serves assets first — HTML, course JSON under [web/public/data/](../web/public/data/), and images are free static assets (edge-cached; even `304` revalidations cost nothing). Only the PostHog proxy at `/x8m2k/*` runs as a Pages Function, the sole path billed against the Functions limit (100k/day free) — so eager-loading ~400 course files per session is cheap. Cloudflare bills only requests matched by the auto-generated `_routes.json` `include` (Pages derives it from `functions/`; ours is just `/x8m2k/*`), so adding a `functions/` route is what would re-bill the catalog. See [decisions.md](decisions.md#static-export-over-the-next-on-pages-adapter).
 
 ## Analytics
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,12 +142,10 @@ Create local web env vars in `web/.env.local`.
 ```bash
 ALLOWED_DEV_ORIGINS=
 NEXT_PUBLIC_POSTHOG_KEY=
-NEXT_PUBLIC_POSTHOG_HOST=
 ```
 
 - `ALLOWED_DEV_ORIGINS`: comma-separated dev origins for LAN/mobile testing.
 - `NEXT_PUBLIC_POSTHOG_KEY`: optional PostHog project key. Local development works without it.
-- `NEXT_PUBLIC_POSTHOG_HOST`: optional PostHog ingest host; defaults to `https://us.i.posthog.com`.
 
 ## Data Pipeline
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# cloudflare (wrangler local dev/build state)
+.wrangler/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/web/functions/tsconfig.json
+++ b/web/functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/web/functions/x8m2k/[[path]].ts
+++ b/web/functions/x8m2k/[[path]].ts
@@ -1,0 +1,25 @@
+// Reverse proxy to PostHog so analytics ride our own origin and ad blockers
+// don't see PostHog's domain. Replaces the next.config rewrite (dropped under
+// output: 'export') and is our only Function; everything else is static.
+//
+// Single-host to match the old rewrite exactly; splitting the assets host is #177.
+
+interface Env {
+  POSTHOG_HOST?: string // optional binding to override the region host
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { request, params, env } = context
+  const host = env.POSTHOG_HOST ?? 'https://us.i.posthog.com'
+
+  // Catch-all segments: array for a/b, string for a, undefined for the bare path.
+  const path = Array.isArray(params.path) ? params.path.join('/') : (params.path ?? '')
+  const search = new URL(request.url).search
+
+  return fetch(`${host}/${path}${search}`, {
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    redirect: 'manual',
+  })
+}

--- a/web/functions/x8m2k/[[path]].ts
+++ b/web/functions/x8m2k/[[path]].ts
@@ -20,6 +20,6 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     method: request.method,
     headers: request.headers,
     body: request.body,
-    redirect: 'manual',
+    redirect: 'follow', // resolve redirects server-side so the browser never sees PostHog's domain
   })
 }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -5,6 +5,12 @@ const allowedDevOrigins = process.env.ALLOWED_DEV_ORIGINS?.split(',')
   .filter(Boolean)
 
 const nextConfig: NextConfig = {
+  // Static export: assets served by Cloudflare's static layer, not a Function.
+  // See docs/decisions.md. The PostHog rewrite moved to functions/x8m2k/[[path]].ts
+  // (rewrites() aren't supported here); next/image needs unoptimized without a server.
+  output: 'export',
+  images: { unoptimized: true },
+
   turbopack: {
     root: process.cwd(),
   },
@@ -12,15 +18,6 @@ const nextConfig: NextConfig = {
   ...(process.env.NODE_ENV === 'development' && allowedDevOrigins?.length
     ? { allowedDevOrigins }
     : {}),
-
-  async rewrites() {
-    return [
-      {
-        source: '/x8m2k/:path*',
-        destination: `${process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com'}/:path*`,
-      },
-    ]
-  },
 }
 
 export default nextConfig

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "zod": "^4.0.15"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260712.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -292,6 +293,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260712.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260712.1.tgz",
+      "integrity": "sha512-tkQ18Lz41EPXLzh4cSuIGQzztDVueuGfTcjlP4M7Qa0rfHpVBNItf3GRkd9O0JgiXs9csAwz/kVv7sjYXSoF2w==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2116,7 +2116,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3554,7 +3553,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6715,6 +6713,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7200,13 +7211,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -8238,19 +8249,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -8794,19 +8792,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
@@ -8895,19 +8880,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/web-vitals": {

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "zod": "^4.0.15"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260712.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p functions/tsconfig.json",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -29,5 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "functions"]
 }

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -5,8 +5,10 @@
   // dashboard settings, and its config file has no field for it.
   "name": "another-cuhk-course-planner",
   "compatibility_date": "2025-08-25",
+  // Required even though our proxy uses no Node APIs: Cloudflare compiles
+  // functions/ into one Worker whose runtime shim imports node:stream, so the
+  // publish step fails with "No such module node:stream" without this flag.
+  // (This file is the source of truth, so omitting it disables the flag.)
+  "compatibility_flags": ["nodejs_compat"],
   "pages_build_output_dir": "out"
-  // No compatibility_flags on purpose. The static export leaves only the
-  // /x8m2k PostHog proxy, which uses Web-standard Worker APIs; nodejs_compat
-  // (required by the old next-on-pages runtime) is no longer needed.
 }

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  // Pins the Pages runtime and build output in-repo, read by both local
+  // `wrangler pages dev` and Cloudflare's build (so local matches production).
+  // The build command can't live here — Pages runs it from the project's
+  // dashboard settings, and its config file has no field for it.
+  "name": "another-cuhk-course-planner",
+  "compatibility_date": "2025-08-25",
+  "pages_build_output_dir": "out"
+  // No compatibility_flags on purpose. The static export leaves only the
+  // /x8m2k PostHog proxy, which uses Web-standard Worker APIs; nodejs_compat
+  // (required by the old next-on-pages runtime) is no longer needed.
+}


### PR DESCRIPTION
## Why
During add-drop, Pages Functions hit ~78% of the 100k/day free limit. `@cloudflare/next-on-pages` routed every request except `/_next/static/*` through the Worker, so the ~400 course-data JSON files each session eager-loads were billed as Function requests. The quota counts requests, not bytes, so caching/304s didn't help.

## What
- `output: 'export'` — Cloudflare serves HTML/data/images as free static assets; only the PostHog `/x8m2k/*` proxy stays a Function.
- Proxy moved from a `next.config` rewrite (unsupported under export) to `web/functions/x8m2k/[[path]].ts`, typed via `@cloudflare/workers-types` (typecheck enforces it).
- `images.unoptimized` since next/image needs no server; dropped the now-stale `legacy-peer-deps`.
- Docs: serving/billing model + decision rationale.

## Verified locally
Fresh install without legacy-peer-deps, `npm run build` → `out/` with data, `wrangler pages dev out` (static served directly; proxy reaches PostHog on GET/POST), typecheck, tests, lint.

## ⚠️ Merge coordination — flip the Cloudflare dashboard build config at/around merge, or prod breaks
- Build command: `npx @cloudflare/next-on-pages` → `npm run build`
- Build output directory: `.vercel/output/static` → `out`
- Root directory `web` unchanged

## Follow-ups
- #177 — split the proxy's assets host
- #178 — automated routing/quota guards