### PR TITLE
fix: opt out of browser translation to stop React DOM crashes

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -65,6 +65,10 @@ export const metadata: Metadata = {
   },
 
   other: {
+    // Stop Chrome/Edge offering to translate. Their translators rewrite text nodes
+    // out from under React, which crashes the app on the next re-render.
+    google: 'notranslate',
+
     'application/ld+json': JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'WebApplication',
@@ -83,7 +87,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" translate="no">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
         <MobileDesktopNotice />


### PR DESCRIPTION
Chrome/Edge translation rewrites text nodes in place, so React's stored node references go stale and the next re-render throws NotFoundError on removeChild, killing the page. Seen in error tracking across 3 users, all desktop Chrome/Edge with zh-TW; reproducible by translating and toggling filters.

translate="no" + notranslate opt out of built-in translation. The app is English-only by design and CUHK's course data is English regardless, so translating the surrounding chrome was never worth a crash.