### PR TITLE
refactor: notify users on course data removal

### DIFF
--- a/docs/components/shopping-cart.md
+++ b/docs/components/shopping-cart.md
@@ -27,8 +27,9 @@ Flags an enrolled section that changed (time, location, instructor, or language)
 
 - The rendered timetable is always the fresh scrape. What the user _last saw_ is kept as an invisible per-section signature (`lastSeenSections` on `CourseEnrollment`); a section whose current signature differs is surfaced as changed.
 - That signature advances only on add / section-change / sync / dismiss — never on plain reload — so a note persists across reloads until dismissed and re-fires on further change. Sync only fills in _missing_ signatures, so fresh data the user hasn't seen yet isn't retroactively flagged.
-- Compares time + location + instructor + language; ignores `dates` and availability; only `selectedSections`. A summary banner plus an amber highlight on the exact changed value show it; logic lives in [courseUtils.ts](../../web/src/lib/courseUtils.ts) (`sectionSignature`, `diffEnrollment`, `diffSectionDetail`).
-- Cancellation (a section or course _disappearing_) stays on the `isInvalid` path above — "gone" has no before/after to show.
+- Compares time + location + instructor + language; ignores `dates` and availability; only `selectedSections`. Detection compares meeting positions to decide whether to show the summary banner; detail rows use content-based set differences so a deletion does not make later meetings look changed. Logic lives in [courseUtils.ts](../../web/src/lib/courseUtils.ts) (`sectionSignature`, `diffEnrollment`, `diffSectionDetail`).
+- Added or removed meetings get an amber row; removed meetings also use strikethrough and appear after the current rows. Changes that pair one-to-one highlight only the fields that moved.
+- A whole course or section disappearing stays on the `isInvalid` path above. A meeting disappearing from a section that still exists stays in the valid card as a removed row.
 
 ## Summary Semantics
 

--- a/docs/components/shopping-cart.md
+++ b/docs/components/shopping-cart.md
@@ -19,6 +19,7 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 ## Invalid Enrollments
 
 - Invalid courses (marked by background sync) are rendered in orange with the reason and last-synced time, not deleted — the user decides whether to remove them. See [architecture.md](../architecture.md#browser-state).
+- Invalid courses also count in the changed-course banner and its "Show" cycle. They remain there until removed or restored; dismiss only acknowledges ordinary section-detail changes.
 - Re-adding an invalid course from search clears `isInvalid`/`invalidReason`/`lastSynced` and refreshes the stale `course` object, via `updateExistingEnrollment` in [courseUtils.ts](../../web/src/lib/courseUtils.ts).
 
 ## Change Detection

--- a/docs/components/shopping-cart.md
+++ b/docs/components/shopping-cart.md
@@ -2,7 +2,7 @@
 
 **File:** [web/src/components/ShoppingCart.tsx](../../web/src/components/ShoppingCart.tsx)
 
-Lists enrolled courses with section details, availability, conflicts, and per-course actions (hide, remove, cycle sections). State lives in [page.tsx](../../web/src/app/page.tsx); the cart only renders it and raises handlers.
+Lists enrolled courses with section details, availability, conflicts, and per-course actions (hide, remove, cycle sections). State lives in [page.tsx](../../web/src/app/page.tsx); the cart renders it and raises handlers.
 
 Only non-obvious constraints and rationale are documented here; the code is the reference for behavior.
 
@@ -13,20 +13,21 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 
 ## Visibility and Selection
 
-- Hidden and invalid cards are not selectable; hiding a currently selected course also deselects it.
+- Hidden cards are not selectable; hiding a currently selected course also deselects it. Invalid cards remain selectable in the cart, but have no timetable events.
 - Visibility is not just cosmetic: it feeds calendar conflict detection and ICS export (see [weekly-calendar.md](weekly-calendar.md#ics-export)).
 
 ## Invalid Enrollments
 
-- Invalid courses (marked by background sync) are rendered in orange with the reason and last-synced time, not deleted — the user decides whether to remove them. See [architecture.md](../architecture.md#browser-state).
-- Invalid courses also count in the changed-course banner and its "Show" cycle. They remain there until removed or restored; dismiss only acknowledges ordinary section-detail changes.
-- Re-adding an invalid course from search clears `isInvalid`/`invalidReason`/`lastSynced` and refreshes the stale `course` object, via `updateExistingEnrollment` in [courseUtils.ts](../../web/src/lib/courseUtils.ts).
+- Invalid courses (marked by background sync) stay in the cart with an amber status and last-synced time — only the user removes them. See [architecture.md](../architecture.md#browser-state).
+- A new invalid state joins the banner's Review queue. **Dismiss all** acknowledges both invalid and section-detail changes; the unavailable status remains but its explanation collapses. A different reason or set of missing sections alerts again.
+- Re-adding an invalid course from search clears its invalid and acknowledgment state and refreshes the stale `course` object, via `updateExistingEnrollment` in [courseUtils.ts](../../web/src/lib/courseUtils.ts).
 
 ## Change Detection
 
 Flags an enrolled section that changed (time, location, instructor, or language) since the user last saw it, so they know to re-export their `.ics` or update a saved screenshot — which the app can't do for them.
 
 - The rendered timetable is always the fresh scrape. What the user _last saw_ is kept as an invisible per-section signature (`lastSeenSections` on `CourseEnrollment`); a section whose current signature differs is surfaced as changed.
+- **Review next** selects changed cards from top to bottom. Invalid enrollments use the same selection styling but remain excluded from the timetable.
 - That signature advances only on add / section-change / sync / dismiss — never on plain reload — so a note persists across reloads until dismissed and re-fires on further change. Sync only fills in _missing_ signatures, so fresh data the user hasn't seen yet isn't retroactively flagged.
 - Compares time + location + instructor + language; ignores `dates` and availability; only `selectedSections`. Detection compares meeting positions to decide whether to show the summary banner; detail rows use content-based set differences so a deletion does not make later meetings look changed. Logic lives in [courseUtils.ts](../../web/src/lib/courseUtils.ts) (`sectionSignature`, `diffEnrollment`, `diffSectionDetail`).
 - Added or removed meetings get an amber row; removed meetings also use strikethrough and appear after the current rows. Changes that pair one-to-one highlight only the fields that moved.

--- a/docs/components/shopping-cart.md
+++ b/docs/components/shopping-cart.md
@@ -27,10 +27,9 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 Flags an enrolled section that changed (time, location, instructor, or language) since the user last saw it, so they know to re-export their `.ics` or update a saved screenshot — which the app can't do for them.
 
 - The rendered timetable is always the fresh scrape. What the user _last saw_ is kept as an invisible per-section signature (`lastSeenSections` on `CourseEnrollment`); a section whose current signature differs is surfaced as changed.
-- **Review next** selects changed cards from top to bottom. Invalid enrollments use the same selection styling but remain excluded from the timetable.
 - That signature advances only on add / section-change / sync / dismiss — never on plain reload — so a note persists across reloads until dismissed and re-fires on further change. Sync only fills in _missing_ signatures, so fresh data the user hasn't seen yet isn't retroactively flagged.
 - Compares time + location + instructor + language; ignores `dates` and availability; only `selectedSections`. Detection compares meeting positions to decide whether to show the summary banner; detail rows use content-based set differences so a deletion does not make later meetings look changed. Logic lives in [courseUtils.ts](../../web/src/lib/courseUtils.ts) (`sectionSignature`, `diffEnrollment`, `diffSectionDetail`).
-- Added or removed meetings get an amber row; removed meetings also use strikethrough and appear after the current rows. Changes that pair one-to-one highlight only the fields that moved.
+- Equal added/removed counts pair positionally into field-level "previously" highlights; unequal counts show whole rows as added/removed rather than guessing pairs — a wrong before/after is worse than none.
 - A whole course or section disappearing stays on the `isInvalid` path above. A meeting disappearing from a section that still exists stays in the valid card as a removed row.
 
 ## Summary Semantics

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -18,6 +18,7 @@ import {
   parseSectionTypes,
   sortSectionsByPriority,
   updateExistingEnrollment,
+  markCourseUnavailable,
   extractAcademicYearCode,
   readStoredEnrollments,
   recordSeenSections,
@@ -499,22 +500,13 @@ export default function Home() {
 
           if (!freshCourse) {
             console.warn(`⚠️ Course ${courseKey} no longer exists in fresh data`)
-            // Mark as invalid but preserve for user to see
-            return {
-              ...enrollment,
-              isInvalid: true,
-              invalidReason: 'Course no longer available',
-            }
+            return markCourseUnavailable(enrollment, timestamp)
           }
 
           // Find fresh sections for current term
           const termData = freshCourse.terms.find((t) => t.termName === currentTerm)
           if (!termData) {
-            return {
-              ...enrollment,
-              isInvalid: true,
-              invalidReason: 'Course no longer available',
-            }
+            return markCourseUnavailable(enrollment, timestamp)
           }
 
           // Update sections with fresh data

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
   markCourseUnavailable,
   extractAcademicYearCode,
   readStoredEnrollments,
+  recordSeenChanges,
   recordSeenSections,
   diffEnrollment,
 } from '@/lib/courseUtils'
@@ -378,9 +379,7 @@ export default function Home() {
   }
 
   const handleDismissAllChanges = () => {
-    setCourseEnrollments((prev) =>
-      prev.map((enrollment) => recordSeenSections(enrollment, { onlyMissing: false }))
-    )
+    setCourseEnrollments((prev) => prev.map(recordSeenChanges))
   }
 
   const handleAddCourse = (
@@ -537,6 +536,9 @@ export default function Home() {
               selectedSections: sortSectionsByPriority(syncedSections, freshCourse, currentTerm),
               isInvalid: hasInvalidSections,
               invalidReason: hasInvalidSections ? 'Some sections no longer available' : undefined,
+              lastSeenInvalidState: hasInvalidSections
+                ? enrollment.lastSeenInvalidState
+                : undefined,
               lastSynced: timestamp, // Track when we last synced this enrollment
             },
             { onlyMissing: true }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -212,8 +212,8 @@ export default function Home() {
     return detectConflicts(events)
   }, [courseEnrollments])
 
-  // Sections that changed (time/location/instructor/language) since the user last saw them.
-  // Cancellations already have their own isInvalid card, so skip those enrollments here.
+  // Section details that changed since the user last saw them. Invalid enrollments surface
+  // through the cart's banner/card instead, so they do not need a meeting-level diff.
   const sectionChanges = useMemo(() => {
     const map = new Map<string, SectionChange[]>()
     for (const enrollment of courseEnrollments) {

--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -20,18 +20,16 @@ import {
 import {
   parseSectionTypes,
   isCourseEnrollmentComplete,
-  getUniqueMeetings,
+  sectionSignature,
   getSectionPrefix,
   categorizeCompatibleSections,
   getSectionTypePriority,
-  formatTimeCompact,
   formatInstructorsCompact,
   formatSyncTimestamp,
   getAvailabilityBadges,
   getAvailabilityBadgeStyle,
   checkSectionConflict,
   googleSearchAndOpen,
-  googleMapsSearchAndOpen,
   cuhkLibrarySearchAndOpen,
   getDayIndex,
   getAggregateSeatInfo,
@@ -75,7 +73,7 @@ import {
 import { TermSelector } from '@/components/TermSelector'
 import { CuhkLibraryImageIcon } from '@/components/icons/CuhkLibraryImageIcon'
 import { GoogleIcon } from '@/components/icons/GoogleIcon'
-import { GoogleMapsIcon } from '@/components/icons/GoogleMapsIcon'
+import { MeetingRowCard } from '@/components/MeetingRowCard'
 
 // Using clean internal types only
 
@@ -2495,73 +2493,14 @@ function CourseCard({
                                 </div>
                               )}
 
-                              {/* Meetings displayed in unified 3-row emoji format */}
+                              {/* Meeting rows are normalized and deduped by sectionSignature. */}
                               <div className="space-y-1">
-                                {getUniqueMeetings(section.meetings).map((meeting, index) => {
-                                  const formattedTime = formatTimeCompact(meeting?.time || 'TBA')
-                                  const formattedInstructor = formatInstructorsCompact(
-                                    meeting?.instructors || 'TBA'
-                                  )
-                                  const location = meeting?.location || 'TBA'
-
-                                  return (
-                                    <div
-                                      key={index}
-                                      className="bg-white border border-gray-200 rounded px-2 py-1.5 shadow-sm"
-                                    >
-                                      {/* Row 1: Time */}
-                                      <div className="flex items-center gap-1 text-[11px]">
-                                        <span>⏰</span>
-                                        <span className="font-mono text-gray-600">
-                                          {formattedTime}
-                                        </span>
-                                      </div>
-                                      {/* Row 2: Instructor */}
-                                      <div className="flex items-center gap-1 text-gray-600 text-[11px] mt-1">
-                                        <span>🧑🏻‍🏫</span>
-                                        <div className="flex items-center gap-1 min-w-0 flex-1">
-                                          <span className="truncate" title={formattedInstructor}>
-                                            {formattedInstructor}
-                                          </span>
-                                          {formattedInstructor !== 'Staff' && (
-                                            <button
-                                              onClick={(e) => {
-                                                e.stopPropagation()
-                                                googleSearchAndOpen(`CUHK ${formattedInstructor}`)
-                                              }}
-                                              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
-                                              title={`Search Google for "CUHK ${formattedInstructor}"`}
-                                            >
-                                              <GoogleIcon className="size-3" />
-                                            </button>
-                                          )}
-                                        </div>
-                                      </div>
-                                      {/* Row 3: Location */}
-                                      <div className="flex items-center gap-1 text-gray-600 text-[11px] mt-1">
-                                        <span>📍</span>
-                                        <div className="flex items-center gap-1 min-w-0 flex-1">
-                                          <span className="truncate" title={location}>
-                                            {location}
-                                          </span>
-                                          {location !== 'TBA' &&
-                                            location !== 'No Room Required' && (
-                                              <button
-                                                onClick={(e) => {
-                                                  e.stopPropagation()
-                                                  googleMapsSearchAndOpen(location)
-                                                }}
-                                                className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
-                                                title={`View "${location}" on Google Maps`}
-                                              >
-                                                <GoogleMapsIcon className="size-3" />
-                                              </button>
-                                            )}
-                                        </div>
-                                      </div>
-                                    </div>
-                                  )
-                                })}
+                                {sectionSignature(section).meetings.map((meeting, index) => (
+                                  <MeetingRowCard
+                                    key={index}
+                                    row={{ status: 'unchanged', meeting }}
+                                  />
+                                ))}
                               </div>
                             </div>
                           </div>

--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -26,6 +26,7 @@ import {
   getSectionTypePriority,
   formatTimeCompact,
   formatInstructorsCompact,
+  formatSyncTimestamp,
   getAvailabilityBadges,
   getAvailabilityBadgeStyle,
   checkSectionConflict,
@@ -963,17 +964,7 @@ export default function CourseSearch({
                       <span className="w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse" />
                     </span>
                     <span className="whitespace-nowrap">
-                      Last Data Sync:{' '}
-                      {lastDataUpdate.toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'short',
-                        day: 'numeric',
-                      })}{' '}
-                      {lastDataUpdate.toLocaleTimeString([], {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        hour12: false,
-                      })}
+                      Last Data Sync: {formatSyncTimestamp(lastDataUpdate)}
                     </span>
                   </div>
                 </>

--- a/web/src/components/MeetingRowCard.tsx
+++ b/web/src/components/MeetingRowCard.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import {
+  formatTimeCompact,
+  formatInstructorsCompact,
+  googleSearchAndOpen,
+  googleMapsSearchAndOpen,
+} from '@/lib/courseUtils'
+import type { MeetingRow } from '@/lib/types'
+import { GoogleIcon } from '@/components/icons/GoogleIcon'
+import { GoogleMapsIcon } from '@/components/icons/GoogleMapsIcon'
+
+// Amber text marks a changed value without shifting the surrounding row.
+// Exported for the cart's language-of-instruction line, which uses the same treatment.
+export const changedText = 'rounded bg-amber-100 text-amber-800 cursor-help'
+
+// One meeting in the unified 3-row emoji format, styled by its change status.
+// Shared by the cart (all statuses) and search results (always 'unchanged').
+export function MeetingRowCard({ row }: { row: MeetingRow }) {
+  const { meeting } = row
+  const before = row.status === 'changed' ? row.before : undefined
+  const fields = row.status === 'changed' ? row.fields : undefined
+  const formattedTime = formatTimeCompact(meeting.time || 'TBA')
+  const formattedInstructor = formatInstructorsCompact(meeting.instructor || 'TBA')
+  const location = meeting.location || 'TBA'
+
+  let containerClass = 'bg-white border-gray-200'
+  let valueClass = 'text-gray-600'
+  let tooltip: string | undefined
+  let wholeMeetingChange = false
+
+  switch (row.status) {
+    case 'unchanged':
+      break
+    case 'added':
+      containerClass = 'bg-amber-50 border-amber-200 cursor-help'
+      tooltip = 'New meeting (added since you last checked)'
+      wholeMeetingChange = true
+      break
+    case 'changed':
+      break
+    case 'removed':
+      containerClass = 'bg-amber-50 border-amber-200 cursor-help'
+      valueClass = 'text-gray-400 line-through'
+      tooltip = 'This meeting was removed since you last checked'
+      wholeMeetingChange = true
+      break
+  }
+
+  return (
+    <div className={`rounded border px-2 py-1.5 shadow-sm ${containerClass}`} title={tooltip}>
+      {/* Row 1: Time */}
+      <div className="flex items-center gap-1 text-[11px]">
+        <span>⏰</span>
+        <span
+          className={`font-mono ${fields?.time ? changedText : valueClass}`}
+          title={fields?.time && before ? `Previously ${before.time}` : undefined}
+        >
+          {formattedTime}
+        </span>
+      </div>
+      {/* Row 2: Instructor */}
+      <div className="flex items-center gap-1 text-[11px] mt-1">
+        <span>🧑🏻‍🏫</span>
+        <div className="flex items-center gap-1 min-w-0 flex-1">
+          <span
+            className={`truncate ${fields?.instructor ? changedText : valueClass}`}
+            title={
+              fields?.instructor && before
+                ? `Previously ${before.instructor}`
+                : wholeMeetingChange
+                  ? undefined
+                  : formattedInstructor
+            }
+          >
+            {formattedInstructor}
+          </span>
+          {formattedInstructor !== 'Staff' && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                googleSearchAndOpen(`CUHK ${formattedInstructor}`)
+              }}
+              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
+              title={`Search Google for "CUHK ${formattedInstructor}"`}
+            >
+              <GoogleIcon className="size-3" />
+            </button>
+          )}
+        </div>
+      </div>
+      {/* Row 3: Location */}
+      <div className="flex items-center gap-1 text-[11px] mt-1">
+        <span>📍</span>
+        <div className="flex items-center gap-1 min-w-0 flex-1">
+          <span
+            className={`truncate ${fields?.location ? changedText : valueClass}`}
+            title={
+              fields?.location && before
+                ? `Previously ${before.location}`
+                : wholeMeetingChange
+                  ? undefined
+                  : location
+            }
+          >
+            {location}
+          </span>
+          {location !== 'TBA' && location !== 'No Room Required' && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                googleMapsSearchAndOpen(location)
+              }}
+              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
+              title={`View "${location}" on Google Maps`}
+            >
+              <GoogleMapsIcon className="size-3" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -10,6 +10,7 @@ import {
   sectionSignature,
   formatTimeCompact,
   formatInstructorsCompact,
+  formatSyncTimestamp,
   getSectionTypePriority,
   categorizeCompatibleSections,
   getAvailabilityBadges,
@@ -609,11 +610,8 @@ export default function ShoppingCart({
                         )}
                       </div>
                       {enrollment.lastSynced && (
-                        <div className="text-xs text-gray-500 mt-2">Last synced:</div>
-                      )}
-                      {enrollment.lastSynced && (
-                        <div className="text-xs text-gray-500">
-                          {enrollment.lastSynced.toLocaleString()}
+                        <div className="mt-2 text-xs text-gray-500">
+                          Last synced · {formatSyncTimestamp(enrollment.lastSynced)}
                         </div>
                       )}
                     </div>

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -445,10 +445,10 @@ export default function ShoppingCart({
               const isVisible = enrollment.isVisible // Use enrollment visibility directly
               const isSelected = selectedEnrollment === enrollment.courseId
               const isInvalid = enrollment.isInvalid // Check if enrollment has invalid data
-              const invalidMessage =
-                enrollment.invalidReason === 'Course no longer available'
-                  ? `CUHK no longer offers this course in ${currentTerm}. It's off your calendar; remove it from your cart when ready.`
-                  : enrollment.invalidReason
+              const isCourseRemoved = enrollment.invalidReason === 'Course no longer available'
+              const invalidMessage = isCourseRemoved
+                ? `This course is no longer offered in ${currentTerm}. It's off your timetable but stays here until you're ready to remove it.`
+                : enrollment.invalidReason
               const changes = sectionChanges?.get(enrollment.courseId)
 
               return (
@@ -592,9 +592,21 @@ export default function ShoppingCart({
                   {isInvalid ? (
                     /* Show simplified invalid state */
                     <div className="bg-orange-50 border border-orange-200 rounded px-3 py-2">
-                      <div className="flex items-center gap-2 text-xs text-orange-600">
-                        <AlertTriangle className="w-4 h-4 text-orange-500 flex-shrink-0" />
-                        <span>{invalidMessage}</span>
+                      <div className="flex items-start gap-2 text-xs leading-4 text-orange-600">
+                        <AlertTriangle className="mt-0.5 size-4 flex-shrink-0 text-orange-500" />
+                        {isCourseRemoved ? (
+                          <div className="min-w-0">
+                            <p className="font-medium text-orange-700">
+                              This course is no longer offered in {currentTerm}.
+                            </p>
+                            <p className="mt-1">
+                              It&apos;s off your timetable but stays here until you&apos;re ready to
+                              remove it.
+                            </p>
+                          </div>
+                        ) : (
+                          <span>{invalidMessage}</span>
+                        )}
                       </div>
                       {enrollment.lastSynced && (
                         <div className="text-xs text-gray-500 mt-2">Last synced:</div>

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -445,6 +445,10 @@ export default function ShoppingCart({
               const isVisible = enrollment.isVisible // Use enrollment visibility directly
               const isSelected = selectedEnrollment === enrollment.courseId
               const isInvalid = enrollment.isInvalid // Check if enrollment has invalid data
+              const invalidMessage =
+                enrollment.invalidReason === 'Course no longer available'
+                  ? `CUHK no longer offers this course in ${currentTerm}. It's off your calendar; remove it from your cart when ready.`
+                  : enrollment.invalidReason
               const changes = sectionChanges?.get(enrollment.courseId)
 
               return (
@@ -485,7 +489,7 @@ export default function ShoppingCart({
                     !isVisible && !isInvalid
                       ? 'Course is hidden from calendar. Click the eye icon to show it and enable selection.'
                       : isInvalid
-                        ? enrollment.invalidReason || 'Course data is outdated'
+                        ? invalidMessage || 'Course data is outdated'
                         : undefined
                   }
                   onClick={() => {
@@ -528,7 +532,7 @@ export default function ShoppingCart({
                       {isInvalid && (
                         <div
                           className="flex size-5 items-center justify-center"
-                          title={enrollment.invalidReason || 'Course data is outdated'}
+                          title={invalidMessage || 'Course data is outdated'}
                         >
                           <AlertTriangle className="size-3.5 text-orange-500" />
                         </div>
@@ -590,7 +594,7 @@ export default function ShoppingCart({
                     <div className="bg-orange-50 border border-orange-200 rounded px-3 py-2">
                       <div className="flex items-center gap-2 text-xs text-orange-600">
                         <AlertTriangle className="w-4 h-4 text-orange-500 flex-shrink-0" />
-                        <span>{enrollment.invalidReason}</span>
+                        <span>{invalidMessage}</span>
                       </div>
                       {enrollment.lastSynced && (
                         <div className="text-xs text-gray-500 mt-2">Last synced:</div>

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -458,9 +458,16 @@ export default function ShoppingCart({
                   : undefined
               const hasUnseenInvalid = hasUnseenInvalidChange(enrollment)
               const isCourseRemoved = enrollment.invalidReason === 'Course no longer available'
-              const invalidMessage = isCourseRemoved
-                ? `This course is no longer offered in ${currentTerm}. It's off your timetable but stays here until you're ready to remove it.`
-                : enrollment.invalidReason
+              const invalidHeading = isCourseRemoved
+                ? `This course is no longer offered in ${currentTerm}.`
+                : enrollment.invalidReason || 'Course data is outdated'
+              const courseRemovedDetail =
+                "It's off your timetable but stays here until you're ready to remove it."
+              const invalidDetail =
+                isCourseRemoved && hasUnseenInvalid ? courseRemovedDetail : undefined
+              const invalidTooltip = isCourseRemoved
+                ? `${invalidHeading} ${courseRemovedDetail}`
+                : invalidHeading
               const changes = sectionChanges?.get(enrollment.courseId)
 
               return (
@@ -497,7 +504,7 @@ export default function ShoppingCart({
                     !isVisible && !isInvalid
                       ? 'Course is hidden from calendar. Click the eye icon to show it and enable selection.'
                       : isInvalid
-                        ? invalidMessage || 'Course data is outdated'
+                        ? invalidTooltip
                         : undefined
                   }
                   onClick={() => {
@@ -539,7 +546,7 @@ export default function ShoppingCart({
                       {isInvalid && (
                         <div
                           className="flex size-5 items-center justify-center"
-                          title={invalidMessage || 'Course data is outdated'}
+                          title={invalidTooltip}
                         >
                           <AlertTriangle className="size-3.5 text-amber-600" />
                         </div>
@@ -601,21 +608,10 @@ export default function ShoppingCart({
                     <div className="px-3 py-2">
                       <div className="flex items-start gap-2 text-xs leading-4 text-amber-700">
                         <AlertTriangle className="mt-0.5 size-4 flex-shrink-0 text-amber-600" />
-                        {isCourseRemoved ? (
-                          <div className="min-w-0">
-                            <p className="font-medium text-amber-800">
-                              This course is no longer offered in {currentTerm}.
-                            </p>
-                            {hasUnseenInvalid && (
-                              <p className="mt-1">
-                                It&apos;s off your timetable but stays here until you&apos;re ready
-                                to remove it.
-                              </p>
-                            )}
-                          </div>
-                        ) : (
-                          <span>{invalidMessage}</span>
-                        )}
+                        <div className="min-w-0">
+                          <p className="font-medium text-amber-800">{invalidHeading}</p>
+                          {invalidDetail && <p className="mt-1">{invalidDetail}</p>}
+                        </div>
                       </div>
                       {enrollment.lastSynced && (
                         <div className="mt-2 text-xs text-gray-500">

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -363,7 +363,7 @@ export default function ShoppingCart({
                   }}
                   className={`
                     relative group space-y-2 rounded border border-l-4 p-2
-                    transition-[transform,box-shadow] duration-300 motion-reduce:transition-none
+                    transition-all duration-300 motion-reduce:transition-none
                     ${isInvalid ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}
                     ${isSelected && isSelectable ? `ring-1 shadow-lg scale-[1.02]` : ''}
                     ${isSelectable ? 'cursor-pointer' : 'cursor-not-allowed'}

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -325,7 +325,9 @@ export default function ShoppingCart({
         ) : (
           <div
             ref={scrollContainerRef}
-            className="space-y-3 overflow-y-auto h-full p-1 pr-2 pt-1 pb-2"
+            // Padding leaves room for the selected card's scale + ring; without it the
+            // overflow container clips the card edge flush against the banner/header.
+            className="space-y-3 overflow-y-auto h-full p-1.5 pr-2 pt-2 pb-2"
           >
             {courseEnrollments.map((enrollment) => {
               const isVisible = enrollment.isVisible // Use enrollment visibility directly

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -21,6 +21,7 @@ import {
   checkSectionConflict,
   diffSectionDetail,
   getChangedCourseIds,
+  hasUnseenInvalidChange,
 } from '@/lib/courseUtils'
 import type {
   CourseEnrollment,
@@ -33,9 +34,9 @@ import { analytics } from '@/lib/analytics'
 import { GoogleIcon } from '@/components/icons/GoogleIcon'
 import { GoogleMapsIcon } from '@/components/icons/GoogleMapsIcon'
 
-// Shared style for the change-banner's "Show" / "Dismiss all" buttons.
+// Shared style for the change-banner actions; the grid gives both equal width.
 const bannerButtonClass =
-  'h-5 rounded border border-amber-300 bg-white/50 px-1.5 text-[10px] text-amber-800 hover:bg-amber-100 cursor-pointer'
+  'h-6 w-full rounded border border-amber-300 bg-white/50 px-2 text-[11px] font-medium text-amber-800 hover:bg-amber-100 cursor-pointer'
 
 // Amber text marks a changed value without shifting the surrounding row.
 const changedText = 'rounded bg-amber-100 text-amber-800 cursor-help'
@@ -154,7 +155,7 @@ function renderMeetingRow(row: MeetingRow, key: string) {
 interface ShoppingCartProps {
   courseEnrollments: CourseEnrollment[]
   calendarEvents: CalendarEvent[] // Calendar events for conflict detection
-  selectedEnrollment?: string | null // Enrollment ID that was clicked/selected
+  selectedEnrollment?: string | null // Enrollment ID focused across the cart and calendar
   currentTerm: string // Current term to get available sections
   onToggleVisibility: (enrollmentId: string) => void
   onRemoveCourse: (enrollmentId: string) => void
@@ -243,9 +244,9 @@ export default function ShoppingCart({
     onSectionChange(enrollment.courseId, sectionType, newSection.id)
   }
 
-  // Scroll a course card into view within the cart container, if not already fully visible.
-  // Shared by the selection effect and the "Show" button so both scroll reliably.
-  const scrollEnrollmentIntoView = useCallback((enrollmentId: string) => {
+  // Scroll a course card within the cart. Selection only scrolls when needed; Review always
+  // aligns the target near the top so the queue's cart order is visually predictable.
+  const scrollEnrollmentIntoView = useCallback((enrollmentId: string, alwaysAlign = false) => {
     const container = scrollContainerRef.current
     const element = itemRefs.current.get(enrollmentId)
     if (!container || !element) return
@@ -266,7 +267,7 @@ export default function ShoppingCart({
     const visibleTop = container.scrollTop
     const visibleBottom = container.scrollTop + container.clientHeight
 
-    if (elementTopInContainer < visibleTop || elementBottom > visibleBottom) {
+    if (alwaysAlign || elementTopInContainer < visibleTop || elementBottom > visibleBottom) {
       container.scrollTo({ top: Math.max(0, idealScrollTop), behavior: 'smooth' })
     }
   }, [])
@@ -338,19 +339,17 @@ export default function ShoppingCart({
 
   const statusCounts = getStatusCounts()
 
-  // Changed courses in cart order; "Show" selects the next one (reusing the select/scroll
-  // path that clicking a card or calendar event uses) so the user can step through changes.
+  // Review reuses the cart/calendar focus state. Invalid enrollments have no calendar events,
+  // so focusing one highlights only its cart card.
   const changedCourseIds = getChangedCourseIds(courseEnrollments, sectionChanges)
-  const hasSectionChanges = (sectionChanges?.size ?? 0) > 0
-  const hasInvalidChanges = courseEnrollments.some((enrollment) => enrollment.isInvalid)
-  const showNextChange = () => {
+  const selectedChangeIndex = changedCourseIds.indexOf(selectedEnrollment ?? '')
+  const nextReviewIndex =
+    changedCourseIds.length > 0 ? (selectedChangeIndex + 1) % changedCourseIds.length : 0
+  const reviewNextChange = () => {
     if (!onSelectEnrollment || changedCourseIds.length === 0) return
-    const current = changedCourseIds.indexOf(selectedEnrollment ?? '')
-    const next = changedCourseIds[(current + 1) % changedCourseIds.length]
+    const next = changedCourseIds[nextReviewIndex]
     onSelectEnrollment(next)
-    // Scroll directly too: when next is already the selected course, selectedEnrollment
-    // doesn't change, so the selection effect wouldn't re-fire on its own.
-    scrollEnrollmentIntoView(next)
+    scrollEnrollmentIntoView(next, true)
   }
 
   return (
@@ -394,41 +393,39 @@ export default function ShoppingCart({
 
       {changedCourseIds.length > 0 ? (
         <div
-          className="flex cursor-help items-center justify-between gap-2 border-y border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-800"
+          className="flex flex-col gap-1.5 border-y border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
           title={`CUHK course data changed for ${changedCourseIds.join(', ')}. Review the highlighted cards and update any saved calendar or screenshot.`}
         >
-          <span className="flex items-center gap-1.5">
+          <span className="flex items-center gap-1.5 leading-4">
             <AlertTriangle className="size-3.5 shrink-0 text-amber-600" />
             <span>
               {changedCourseIds.length} {changedCourseIds.length === 1 ? 'course' : 'courses'}{' '}
-              changed
+              changed since you last checked
             </span>
           </span>
-          <span className="flex shrink-0 items-center gap-1.5">
+          <span
+            className={`grid w-full gap-1.5 ${onSelectEnrollment && onDismissAllChanges ? 'grid-cols-2' : 'grid-cols-1'}`}
+          >
             {onSelectEnrollment && (
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={showNextChange}
+                onClick={reviewNextChange}
                 className={bannerButtonClass}
-                title="Scroll to the next changed course"
+                title="Review the next changed course from top to bottom"
               >
-                Show
+                Review next
               </Button>
             )}
-            {onDismissAllChanges && hasSectionChanges && (
+            {onDismissAllChanges && (
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={onDismissAllChanges}
                 className={bannerButtonClass}
-                title={
-                  hasInvalidChanges
-                    ? 'Dismiss timetable changes; unavailable courses remain until removed'
-                    : 'Dismiss all changes'
-                }
+                title="Dismiss all change notifications"
               >
-                {hasInvalidChanges ? 'Dismiss updates' : 'Dismiss all'}
+                Dismiss all
               </Button>
             )}
           </span>
@@ -453,6 +450,13 @@ export default function ShoppingCart({
               const isVisible = enrollment.isVisible // Use enrollment visibility directly
               const isSelected = selectedEnrollment === enrollment.courseId
               const isInvalid = enrollment.isInvalid // Check if enrollment has invalid data
+              const isSelectable = isVisible || isInvalid
+              const accentColor = isInvalid
+                ? '#fbbf24'
+                : enrollment.color
+                  ? getComputedBorderColor(enrollment.color)
+                  : undefined
+              const hasUnseenInvalid = hasUnseenInvalidChange(enrollment)
               const isCourseRemoved = enrollment.invalidReason === 'Course no longer available'
               const invalidMessage = isCourseRemoved
                 ? `This course is no longer offered in ${currentTerm}. It's off your timetable but stays here until you're ready to remove it.`
@@ -470,26 +474,22 @@ export default function ShoppingCart({
                     }
                   }}
                   className={`
-                    border rounded p-2 transition-all duration-300 relative group space-y-2
-                    border-l-4 border-gray-200
-                    ${isInvalid ? 'bg-orange-50 opacity-75' : 'bg-white'}
-                    ${isSelected && isVisible && !isInvalid ? `ring-1 shadow-lg scale-[1.02]` : ''}
-                    ${!isVisible || isInvalid ? 'cursor-not-allowed' : 'cursor-pointer'}
+                    relative group space-y-2 rounded border border-l-4 p-2
+                    transition-[transform,box-shadow] duration-300 motion-reduce:transition-none
+                    ${isInvalid ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}
+                    ${isSelected && isSelectable ? `ring-1 shadow-lg scale-[1.02]` : ''}
+                    ${isSelectable ? 'cursor-pointer' : 'cursor-not-allowed'}
                   `}
                   style={{
-                    ...(isInvalid
+                    ...(accentColor
                       ? {
-                          borderLeftColor: '#fb923c', // orange-400 for invalid courses
+                          borderLeftColor: accentColor,
                         }
-                      : enrollment.color
-                        ? {
-                            borderLeftColor: getComputedBorderColor(enrollment.color), // course color for normal/conflict courses
-                          }
-                        : {}),
-                    // Ring color matches the left border color when selected
-                    ...(isSelected && isVisible && !isInvalid && enrollment.color
+                      : {}),
+                    // Every selected card uses the same accent for its left border and ring.
+                    ...(isSelected && isSelectable && accentColor
                       ? {
-                          '--tw-ring-color': getComputedBorderColor(enrollment.color),
+                          '--tw-ring-color': accentColor,
                         }
                       : {}),
                   }}
@@ -501,8 +501,7 @@ export default function ShoppingCart({
                         : undefined
                   }
                   onClick={() => {
-                    // Only allow selection if the enrollment is visible and not invalid
-                    if (isVisible && !isInvalid && onSelectEnrollment) {
+                    if (isSelectable && onSelectEnrollment) {
                       const newSelection = isSelected ? null : enrollment.courseId
                       onSelectEnrollment(newSelection)
                     }
@@ -542,7 +541,7 @@ export default function ShoppingCart({
                           className="flex size-5 items-center justify-center"
                           title={invalidMessage || 'Course data is outdated'}
                         >
-                          <AlertTriangle className="size-3.5 text-orange-500" />
+                          <AlertTriangle className="size-3.5 text-amber-600" />
                         </div>
                       )}
                       <span className="flex h-full shrink-0 items-center text-xs font-medium leading-5 text-gray-500">
@@ -558,7 +557,7 @@ export default function ShoppingCart({
                         onClick={(e) => {
                           e.stopPropagation()
                           // If making invisible and currently selected, deselect it
-                          if (isVisible && isSelected && onSelectEnrollment) {
+                          if (!isInvalid && isVisible && isSelected && onSelectEnrollment) {
                             onSelectEnrollment(null)
                           }
                           // Toggle visibility for this enrollment
@@ -599,18 +598,20 @@ export default function ShoppingCart({
                   {/* Selected Sections - Compact Display or Invalid Message */}
                   {isInvalid ? (
                     /* Show simplified invalid state */
-                    <div className="bg-orange-50 border border-orange-200 rounded px-3 py-2">
-                      <div className="flex items-start gap-2 text-xs leading-4 text-orange-600">
-                        <AlertTriangle className="mt-0.5 size-4 flex-shrink-0 text-orange-500" />
+                    <div className="px-3 py-2">
+                      <div className="flex items-start gap-2 text-xs leading-4 text-amber-700">
+                        <AlertTriangle className="mt-0.5 size-4 flex-shrink-0 text-amber-600" />
                         {isCourseRemoved ? (
                           <div className="min-w-0">
-                            <p className="font-medium text-orange-700">
+                            <p className="font-medium text-amber-800">
                               This course is no longer offered in {currentTerm}.
                             </p>
-                            <p className="mt-1">
-                              It&apos;s off your timetable but stays here until you&apos;re ready to
-                              remove it.
-                            </p>
+                            {hasUnseenInvalid && (
+                              <p className="mt-1">
+                                It&apos;s off your timetable but stays here until you&apos;re ready
+                                to remove it.
+                              </p>
+                            )}
                           </div>
                         ) : (
                           <span>{invalidMessage}</span>

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Eye, EyeOff, Trash2, AlertTriangle, ChevronLeft, ChevronRight, Search } from 'lucide-react'
 import {
   parseSectionTypes,
-  getUniqueMeetings,
+  sectionSignature,
   formatTimeCompact,
   formatInstructorsCompact,
   getSectionTypePriority,
@@ -19,9 +19,14 @@ import {
   formatCourseCodeWithPrefix,
   checkSectionConflict,
   diffSectionDetail,
-  matchChangedMeeting,
 } from '@/lib/courseUtils'
-import type { CourseEnrollment, CalendarEvent, SectionType, SectionChange } from '@/lib/types'
+import type {
+  CourseEnrollment,
+  CalendarEvent,
+  SectionType,
+  SectionChange,
+  MeetingRow,
+} from '@/lib/types'
 import { analytics } from '@/lib/analytics'
 import { GoogleIcon } from '@/components/icons/GoogleIcon'
 import { GoogleMapsIcon } from '@/components/icons/GoogleMapsIcon'
@@ -29,6 +34,120 @@ import { GoogleMapsIcon } from '@/components/icons/GoogleMapsIcon'
 // Shared style for the change-banner's "Show" / "Dismiss all" buttons.
 const bannerButtonClass =
   'h-5 rounded border border-amber-300 bg-white/50 px-1.5 text-[10px] text-amber-800 hover:bg-amber-100 cursor-pointer'
+
+// Amber text marks a changed value without shifting the surrounding row.
+const changedText = 'rounded bg-amber-100 text-amber-800 cursor-help'
+
+function renderMeetingRow(row: MeetingRow, key: string) {
+  const { meeting } = row
+  const before = row.status === 'changed' ? row.before : undefined
+  const fields = row.status === 'changed' ? row.fields : undefined
+  const formattedTime = formatTimeCompact(meeting.time || 'TBA')
+  const formattedInstructor = formatInstructorsCompact(meeting.instructor || 'TBA')
+  const location = meeting.location || 'TBA'
+
+  let containerClass = 'bg-white border-gray-200'
+  let valueClass = 'text-gray-600'
+  let tooltip: string | undefined
+  let wholeMeetingChange = false
+
+  switch (row.status) {
+    case 'unchanged':
+      break
+    case 'added':
+      containerClass = 'bg-amber-50 border-amber-200 cursor-help'
+      tooltip = 'New meeting (added since you last checked)'
+      wholeMeetingChange = true
+      break
+    case 'changed':
+      break
+    case 'removed':
+      containerClass = 'bg-amber-50 border-amber-200 cursor-help'
+      valueClass = 'text-gray-400 line-through'
+      tooltip = 'This meeting was removed since you last checked'
+      wholeMeetingChange = true
+      break
+  }
+
+  return (
+    <div
+      key={key}
+      className={`rounded border px-2 py-1.5 shadow-sm ${containerClass}`}
+      title={tooltip}
+    >
+      {/* Row 1: Time */}
+      <div className="flex items-center gap-1 text-[11px]">
+        <span>⏰</span>
+        <span
+          className={`font-mono ${fields?.time ? changedText : valueClass}`}
+          title={fields?.time && before ? `Previously ${before.time}` : undefined}
+        >
+          {formattedTime}
+        </span>
+      </div>
+      {/* Row 2: Instructor */}
+      <div className="flex items-center gap-1 text-[11px] mt-1">
+        <span>🧑🏻‍🏫</span>
+        <div className="flex items-center gap-1 min-w-0 flex-1">
+          <span
+            className={`truncate ${fields?.instructor ? changedText : valueClass}`}
+            title={
+              fields?.instructor && before
+                ? `Previously ${before.instructor}`
+                : wholeMeetingChange
+                  ? undefined
+                  : formattedInstructor
+            }
+          >
+            {formattedInstructor}
+          </span>
+          {formattedInstructor !== 'Staff' && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                googleSearchAndOpen(`CUHK ${formattedInstructor}`)
+              }}
+              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
+              title={`Search Google for "CUHK ${formattedInstructor}"`}
+            >
+              <GoogleIcon className="size-3" />
+            </button>
+          )}
+        </div>
+      </div>
+      {/* Row 3: Location */}
+      <div className="flex items-center gap-1 text-[11px] mt-1">
+        <span>📍</span>
+        <div className="flex items-center gap-1 min-w-0 flex-1">
+          <span
+            className={`truncate ${fields?.location ? changedText : valueClass}`}
+            title={
+              fields?.location && before
+                ? `Previously ${before.location}`
+                : wholeMeetingChange
+                  ? undefined
+                  : location
+            }
+          >
+            {location}
+          </span>
+          {location !== 'TBA' && location !== 'No Room Required' && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                googleMapsSearchAndOpen(location)
+              }}
+              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
+              title={`View "${location}" on Google Maps`}
+            >
+              <GoogleMapsIcon className="size-3" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 interface ShoppingCartProps {
   courseEnrollments: CourseEnrollment[]
@@ -516,9 +635,12 @@ export default function ShoppingCart({
                         const changeDetail = sectionChange
                           ? diffSectionDetail(section, sectionChange.before)
                           : undefined
-                        // Amber highlight for a changed value (no border/padding, so the text
-                        // doesn't shift). Same amber family as the summary banner.
-                        const changedText = 'rounded bg-amber-100 text-amber-800 cursor-help'
+                        const meetingRows: MeetingRow[] =
+                          changeDetail?.rows ??
+                          sectionSignature(section).meetings.map((meeting) => ({
+                            status: 'unchanged',
+                            meeting,
+                          }))
 
                         return (
                           <div
@@ -617,107 +739,14 @@ export default function ShoppingCart({
                               </div>
                             )}
 
-                            {/* Unique meetings for this section - consolidated by time+location+instructor */}
+                            {/* Meeting rows are normalized and deduped by sectionSignature. */}
                             <div className="space-y-1">
-                              {getUniqueMeetings(section.meetings).map((meeting, index) => {
-                                const formattedTime = formatTimeCompact(meeting?.time || 'TBA')
-                                const formattedInstructor = formatInstructorsCompact(
-                                  meeting?.instructors || 'TBA'
+                              {meetingRows.map((row, index) =>
+                                renderMeetingRow(
+                                  row,
+                                  row.status === 'removed' ? `removed-${index}` : `live-${index}`
                                 )
-                                const location = meeting?.location || 'TBA'
-                                const meetingChange = changeDetail
-                                  ? matchChangedMeeting(meeting, changeDetail.changedMeetings)
-                                  : undefined
-                                const fields = meetingChange?.fields
-                                const before = meetingChange?.before
-                                // Highlight the whole box only when the meeting changed but can't be
-                                // paired to a previous one (added meeting); otherwise highlight the
-                                // specific field lines that moved.
-                                const isNewMeeting = !!meetingChange && !fields
-
-                                return (
-                                  <div
-                                    key={index}
-                                    className={`rounded border px-2 py-1.5 shadow-sm ${isNewMeeting ? 'bg-amber-50 border-amber-200 cursor-help' : 'bg-white border-gray-200'}`}
-                                    title={
-                                      isNewMeeting
-                                        ? 'New meeting since you last checked'
-                                        : undefined
-                                    }
-                                  >
-                                    {/* Row 1: Time */}
-                                    <div className="flex items-center gap-1 text-[11px]">
-                                      <span>⏰</span>
-                                      <span
-                                        className={`font-mono ${fields?.time ? changedText : 'text-gray-600'}`}
-                                        title={
-                                          fields?.time && before
-                                            ? `Previously ${before.time}`
-                                            : undefined
-                                        }
-                                      >
-                                        {formattedTime}
-                                      </span>
-                                    </div>
-                                    {/* Row 2: Instructor */}
-                                    <div className="flex items-center gap-1 text-[11px] mt-1 text-gray-600">
-                                      <span>🧑🏻‍🏫</span>
-                                      <div className="flex items-center gap-1 min-w-0 flex-1">
-                                        <span
-                                          className={`truncate ${fields?.instructor ? changedText : ''}`}
-                                          title={
-                                            fields?.instructor && before
-                                              ? `Previously ${before.instructor}`
-                                              : formattedInstructor
-                                          }
-                                        >
-                                          {formattedInstructor}
-                                        </span>
-                                        {formattedInstructor !== 'Staff' && (
-                                          <button
-                                            onClick={(e) => {
-                                              e.stopPropagation()
-                                              googleSearchAndOpen(`CUHK ${formattedInstructor}`)
-                                            }}
-                                            className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
-                                            title={`Search Google for "CUHK ${formattedInstructor}"`}
-                                          >
-                                            <GoogleIcon className="size-3" />
-                                          </button>
-                                        )}
-                                      </div>
-                                    </div>
-                                    {/* Row 3: Location */}
-                                    <div className="flex items-center gap-1 text-[11px] mt-1 text-gray-600">
-                                      <span>📍</span>
-                                      <div className="flex items-center gap-1 min-w-0 flex-1">
-                                        <span
-                                          className={`truncate ${fields?.location ? changedText : ''}`}
-                                          title={
-                                            fields?.location && before
-                                              ? `Previously ${before.location}`
-                                              : location
-                                          }
-                                        >
-                                          {location}
-                                        </span>
-                                        {location !== 'TBA' && location !== 'No Room Required' && (
-                                          <button
-                                            onClick={(e) => {
-                                              e.stopPropagation()
-                                              googleMapsSearchAndOpen(location)
-                                            }}
-                                            className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
-                                            title={`View "${location}" on Google Maps`}
-                                          >
-                                            <GoogleMapsIcon className="size-3" />
-                                          </button>
-                                        )}
-                                      </div>
-                                    </div>
-                                  </div>
-                                )
-                              })}
+                              )}
                             </div>
                           </div>
                         )

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -20,6 +20,7 @@ import {
   formatCourseCodeWithPrefix,
   checkSectionConflict,
   diffSectionDetail,
+  getChangedCourseIds,
 } from '@/lib/courseUtils'
 import type {
   CourseEnrollment,
@@ -339,9 +340,9 @@ export default function ShoppingCart({
 
   // Changed courses in cart order; "Show" selects the next one (reusing the select/scroll
   // path that clicking a card or calendar event uses) so the user can step through changes.
-  const changedCourseIds = courseEnrollments
-    .filter((e) => sectionChanges?.has(e.courseId))
-    .map((e) => e.courseId)
+  const changedCourseIds = getChangedCourseIds(courseEnrollments, sectionChanges)
+  const hasSectionChanges = (sectionChanges?.size ?? 0) > 0
+  const hasInvalidChanges = courseEnrollments.some((enrollment) => enrollment.isInvalid)
   const showNextChange = () => {
     if (!onSelectEnrollment || changedCourseIds.length === 0) return
     const current = changedCourseIds.indexOf(selectedEnrollment ?? '')
@@ -391,15 +392,16 @@ export default function ShoppingCart({
         </div>
       </CardHeader>
 
-      {sectionChanges && sectionChanges.size > 0 ? (
+      {changedCourseIds.length > 0 ? (
         <div
           className="flex cursor-help items-center justify-between gap-2 border-y border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-800"
-          title={`CUHK updated the teaching timetable for ${Array.from(sectionChanges.keys()).join(', ')}. Re-export your calendar and update any screenshot you saved.`}
+          title={`CUHK course data changed for ${changedCourseIds.join(', ')}. Review the highlighted cards and update any saved calendar or screenshot.`}
         >
           <span className="flex items-center gap-1.5">
             <AlertTriangle className="size-3.5 shrink-0 text-amber-600" />
             <span>
-              {sectionChanges.size} {sectionChanges.size === 1 ? 'course' : 'courses'} changed
+              {changedCourseIds.length} {changedCourseIds.length === 1 ? 'course' : 'courses'}{' '}
+              changed
             </span>
           </span>
           <span className="flex shrink-0 items-center gap-1.5">
@@ -414,14 +416,19 @@ export default function ShoppingCart({
                 Show
               </Button>
             )}
-            {onDismissAllChanges && (
+            {onDismissAllChanges && hasSectionChanges && (
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={onDismissAllChanges}
                 className={bannerButtonClass}
+                title={
+                  hasInvalidChanges
+                    ? 'Dismiss timetable changes; unavailable courses remain until removed'
+                    : 'Dismiss all changes'
+                }
               >
-                Dismiss all
+                {hasInvalidChanges ? 'Dismiss updates' : 'Dismiss all'}
               </Button>
             )}
           </span>

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -543,14 +543,6 @@ export default function ShoppingCart({
                           <Search className="size-3.5 text-gray-400 hover:text-gray-600" />
                         </Button>
                       )}
-                      {isInvalid && (
-                        <div
-                          className="flex size-5 items-center justify-center"
-                          title={invalidTooltip}
-                        >
-                          <AlertTriangle className="size-3.5 text-amber-600" />
-                        </div>
-                      )}
                       <span className="flex h-full shrink-0 items-center text-xs font-medium leading-5 text-gray-500">
                         {enrollment.course.credits} credits
                       </span>

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -8,15 +8,11 @@ import { Eye, EyeOff, Trash2, AlertTriangle, ChevronLeft, ChevronRight, Search }
 import {
   parseSectionTypes,
   sectionSignature,
-  formatTimeCompact,
-  formatInstructorsCompact,
   formatSyncTimestamp,
   getSectionTypePriority,
   categorizeCompatibleSections,
   getAvailabilityBadges,
   getComputedBorderColor,
-  googleSearchAndOpen,
-  googleMapsSearchAndOpen,
   formatCourseCodeWithPrefix,
   checkSectionConflict,
   diffSectionDetail,
@@ -31,126 +27,11 @@ import type {
   MeetingRow,
 } from '@/lib/types'
 import { analytics } from '@/lib/analytics'
-import { GoogleIcon } from '@/components/icons/GoogleIcon'
-import { GoogleMapsIcon } from '@/components/icons/GoogleMapsIcon'
+import { MeetingRowCard, changedText } from '@/components/MeetingRowCard'
 
 // Shared style for the change-banner actions; the grid gives both equal width.
 const bannerButtonClass =
   'h-6 w-full rounded border border-amber-300 bg-white/50 px-2 text-[11px] font-medium text-amber-800 hover:bg-amber-100 cursor-pointer'
-
-// Amber text marks a changed value without shifting the surrounding row.
-const changedText = 'rounded bg-amber-100 text-amber-800 cursor-help'
-
-function renderMeetingRow(row: MeetingRow, key: string) {
-  const { meeting } = row
-  const before = row.status === 'changed' ? row.before : undefined
-  const fields = row.status === 'changed' ? row.fields : undefined
-  const formattedTime = formatTimeCompact(meeting.time || 'TBA')
-  const formattedInstructor = formatInstructorsCompact(meeting.instructor || 'TBA')
-  const location = meeting.location || 'TBA'
-
-  let containerClass = 'bg-white border-gray-200'
-  let valueClass = 'text-gray-600'
-  let tooltip: string | undefined
-  let wholeMeetingChange = false
-
-  switch (row.status) {
-    case 'unchanged':
-      break
-    case 'added':
-      containerClass = 'bg-amber-50 border-amber-200 cursor-help'
-      tooltip = 'New meeting (added since you last checked)'
-      wholeMeetingChange = true
-      break
-    case 'changed':
-      break
-    case 'removed':
-      containerClass = 'bg-amber-50 border-amber-200 cursor-help'
-      valueClass = 'text-gray-400 line-through'
-      tooltip = 'This meeting was removed since you last checked'
-      wholeMeetingChange = true
-      break
-  }
-
-  return (
-    <div
-      key={key}
-      className={`rounded border px-2 py-1.5 shadow-sm ${containerClass}`}
-      title={tooltip}
-    >
-      {/* Row 1: Time */}
-      <div className="flex items-center gap-1 text-[11px]">
-        <span>⏰</span>
-        <span
-          className={`font-mono ${fields?.time ? changedText : valueClass}`}
-          title={fields?.time && before ? `Previously ${before.time}` : undefined}
-        >
-          {formattedTime}
-        </span>
-      </div>
-      {/* Row 2: Instructor */}
-      <div className="flex items-center gap-1 text-[11px] mt-1">
-        <span>🧑🏻‍🏫</span>
-        <div className="flex items-center gap-1 min-w-0 flex-1">
-          <span
-            className={`truncate ${fields?.instructor ? changedText : valueClass}`}
-            title={
-              fields?.instructor && before
-                ? `Previously ${before.instructor}`
-                : wholeMeetingChange
-                  ? undefined
-                  : formattedInstructor
-            }
-          >
-            {formattedInstructor}
-          </span>
-          {formattedInstructor !== 'Staff' && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                googleSearchAndOpen(`CUHK ${formattedInstructor}`)
-              }}
-              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
-              title={`Search Google for "CUHK ${formattedInstructor}"`}
-            >
-              <GoogleIcon className="size-3" />
-            </button>
-          )}
-        </div>
-      </div>
-      {/* Row 3: Location */}
-      <div className="flex items-center gap-1 text-[11px] mt-1">
-        <span>📍</span>
-        <div className="flex items-center gap-1 min-w-0 flex-1">
-          <span
-            className={`truncate ${fields?.location ? changedText : valueClass}`}
-            title={
-              fields?.location && before
-                ? `Previously ${before.location}`
-                : wholeMeetingChange
-                  ? undefined
-                  : location
-            }
-          >
-            {location}
-          </span>
-          {location !== 'TBA' && location !== 'No Room Required' && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                googleMapsSearchAndOpen(location)
-              }}
-              className="flex-shrink-0 p-0.5 hover:bg-gray-100 rounded cursor-pointer transition-colors duration-200"
-              title={`View "${location}" on Google Maps`}
-            >
-              <GoogleMapsIcon className="size-3" />
-            </button>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
 
 interface ShoppingCartProps {
   courseEnrollments: CourseEnrollment[]
@@ -751,12 +632,9 @@ export default function ShoppingCart({
 
                             {/* Meeting rows are normalized and deduped by sectionSignature. */}
                             <div className="space-y-1">
-                              {meetingRows.map((row, index) =>
-                                renderMeetingRow(
-                                  row,
-                                  row.status === 'removed' ? `removed-${index}` : `live-${index}`
-                                )
-                              )}
+                              {meetingRows.map((row, index) => (
+                                <MeetingRowCard key={index} row={row} />
+                              ))}
                             </div>
                           </div>
                         )

--- a/web/src/components/ShoppingCart.tsx
+++ b/web/src/components/ShoppingCart.tsx
@@ -597,7 +597,7 @@ export default function ShoppingCart({
                   {/* Selected Sections - Compact Display or Invalid Message */}
                   {isInvalid ? (
                     /* Show simplified invalid state */
-                    <div className="px-3 py-2">
+                    <div className="border-t border-amber-200 px-3 py-2">
                       <div className="flex items-start gap-2 text-xs leading-4 text-amber-700">
                         <AlertTriangle className="mt-0.5 size-4 flex-shrink-0 text-amber-600" />
                         <div className="min-w-0">

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   updateExistingEnrollment,
+  markCourseUnavailable,
   sortSectionsByPriority,
   readStoredEnrollments,
   sectionSignature,
@@ -130,6 +131,35 @@ describe('updateExistingEnrollment', () => {
     expect(result.lastSynced).not.toEqual(existing.lastSynced)
     expect(result.course).toEqual(freshCourse)
     expect(result.selectedSections).toEqual([freshSection])
+  })
+})
+
+describe('markCourseUnavailable', () => {
+  it('records when the unavailable course was synced', () => {
+    const enrollment: CourseEnrollment = {
+      courseId: 'CSCI3150',
+      course: {
+        subject: 'CSCI',
+        courseCode: '3150',
+        title: 'Introduction to Operating Systems',
+        credits: 3,
+        terms: [],
+      },
+      selectedSections: [makeSection({})],
+      color: 'bg-blue-500',
+      isVisible: true,
+    }
+    const syncedAt = new Date('2026-07-14T13:27:10.392Z')
+
+    const result = markCourseUnavailable(enrollment, syncedAt)
+
+    expect(result).toMatchObject({
+      isInvalid: true,
+      invalidReason: 'Course no longer available',
+      lastSynced: syncedAt,
+    })
+    expect(result.course).toBe(enrollment.course)
+    expect(result.selectedSections).toBe(enrollment.selectedSections)
   })
 })
 

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -26,11 +26,9 @@ import type {
 } from './types'
 
 describe('formatSyncTimestamp', () => {
-  it('formats live dates and persisted strings identically in 24-hour time', () => {
-    const timestamp = new Date(2026, 6, 14, 21, 27)
-
-    expect(formatSyncTimestamp(timestamp)).toBe('Jul 14, 2026 21:27')
-    expect(formatSyncTimestamp('2026-07-14T21:27:10')).toBe('Jul 14, 2026 21:27')
+  it('formats in 24-hour time and falls back to Unknown for an invalid Date', () => {
+    expect(formatSyncTimestamp(new Date(2026, 6, 14, 21, 27))).toBe('Jul 14, 2026 21:27')
+    expect(formatSyncTimestamp(new Date('corrupt'))).toBe('Unknown')
   })
 })
 
@@ -172,12 +170,24 @@ describe('readStoredEnrollments', () => {
   const enrollments = [{ courseId: 'COMM1180' }] as unknown as CourseEnrollment[]
 
   it('loads the legacy pre-version array format', () => {
-    expect(readStoredEnrollments(enrollments)).toBe(enrollments)
+    expect(readStoredEnrollments(enrollments)).toEqual(enrollments)
   })
 
   it('loads a known version (1..current) and returns its enrollments', () => {
-    expect(readStoredEnrollments({ version: 1, enrollments })).toBe(enrollments)
-    expect(readStoredEnrollments({ version: SCHEDULE_DATA_VERSION, enrollments })).toBe(enrollments)
+    expect(readStoredEnrollments({ version: 1, enrollments })).toEqual(enrollments)
+    expect(readStoredEnrollments({ version: SCHEDULE_DATA_VERSION, enrollments })).toEqual(
+      enrollments
+    )
+  })
+
+  it('revives lastSynced from its persisted ISO string to a Date', () => {
+    const stored = [
+      { courseId: 'COMM1180', lastSynced: '2026-07-14T13:27:10.392Z' },
+    ] as unknown as CourseEnrollment[]
+
+    const loaded = readStoredEnrollments({ version: SCHEDULE_DATA_VERSION, enrollments: stored })
+
+    expect(loaded?.[0].lastSynced).toEqual(new Date('2026-07-14T13:27:10.392Z'))
   })
 
   it('wipes (null) for an unknown/newer version', () => {

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -6,6 +6,8 @@ import {
   readStoredEnrollments,
   sectionSignature,
   diffEnrollment,
+  hasUnseenInvalidChange,
+  recordSeenChanges,
   recordSeenSections,
   diffSectionDetail,
   getChangedCourseIds,
@@ -105,6 +107,7 @@ describe('updateExistingEnrollment', () => {
       isVisible: true,
       isInvalid: true,
       invalidReason: 'Course no longer available',
+      lastSeenInvalidState: { reason: 'Course no longer available', sectionIds: [] },
       lastSynced: new Date('2026-01-01'),
     }
 
@@ -128,6 +131,7 @@ describe('updateExistingEnrollment', () => {
 
     expect(result.isInvalid).toBeFalsy()
     expect(result.invalidReason).toBeUndefined()
+    expect(result.lastSeenInvalidState).toBeUndefined()
     expect(result.lastSynced).toBeInstanceOf(Date)
     expect(result.lastSynced).not.toEqual(existing.lastSynced)
     expect(result.course).toEqual(freshCourse)
@@ -236,6 +240,46 @@ describe('getChangedCourseIds', () => {
     ])
 
     expect(getChangedCourseIds(enrollments, sectionChanges)).toEqual(['invalid', 'changed', 'both'])
+  })
+
+  it('acknowledges section and invalid changes without making the course valid', () => {
+    const section = mkSection('8818', [mkMeeting({ time: 'Mo 2:30PM - 5:15PM' })])
+    const enrollment = {
+      ...mkEnrollment([section], {
+        '8818': {
+          meetings: [{ time: 'stale', location: 'stale', instructor: 'stale' }],
+          language: '',
+        },
+      }),
+      isInvalid: true,
+      invalidReason: 'Some sections no longer available',
+    }
+
+    expect(diffEnrollment(enrollment)).toHaveLength(1)
+    expect(hasUnseenInvalidChange(enrollment)).toBe(true)
+
+    const acknowledged = recordSeenChanges(enrollment)
+
+    expect(diffEnrollment(acknowledged)).toHaveLength(0)
+    expect(hasUnseenInvalidChange(acknowledged)).toBe(false)
+    expect(acknowledged.isInvalid).toBe(true)
+  })
+
+  it('reports a changed invalid state after the previous one was acknowledged', () => {
+    const acknowledged = recordSeenChanges({
+      ...mkEnrollment([]),
+      isInvalid: true,
+      invalidReason: 'Some sections no longer available',
+    })
+    const changedReason = { ...acknowledged, invalidReason: 'Course no longer available' }
+    const changedSections = {
+      ...acknowledged,
+      selectedSections: [makeSection({ id: 'newly-missing', isInvalid: true })],
+    }
+
+    expect(getChangedCourseIds([acknowledged])).toEqual([])
+    expect(getChangedCourseIds([changedReason])).toEqual(['COMM1180'])
+    expect(getChangedCourseIds([changedSections])).toEqual(['COMM1180'])
   })
 })
 

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -7,6 +7,7 @@ import {
   diffEnrollment,
   recordSeenSections,
   diffSectionDetail,
+  formatSyncTimestamp,
   sectionsOverlapInTime,
   checkSectionConflict,
   hasConflictFreeEnrollment,
@@ -19,6 +20,15 @@ import type {
   InternalMeeting,
   SectionSignature,
 } from './types'
+
+describe('formatSyncTimestamp', () => {
+  it('formats live dates and persisted strings identically in 24-hour time', () => {
+    const timestamp = new Date(2026, 6, 14, 21, 27)
+
+    expect(formatSyncTimestamp(timestamp)).toBe('Jul 14, 2026 21:27')
+    expect(formatSyncTimestamp('2026-07-14T21:27:10')).toBe('Jul 14, 2026 21:27')
+  })
+})
 
 function makeSection(overrides: Partial<InternalSection>): InternalSection {
   return {

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -8,6 +8,7 @@ import {
   diffEnrollment,
   recordSeenSections,
   diffSectionDetail,
+  getChangedCourseIds,
   formatSyncTimestamp,
   sectionsOverlapInTime,
   checkSectionConflict,
@@ -220,6 +221,23 @@ function mkEnrollment(
   }
 }
 const sig = (s: InternalSection) => sectionSignature(s)
+
+describe('getChangedCourseIds', () => {
+  it('includes invalid and section-changed courses once in cart order', () => {
+    const enrollments = [
+      { ...mkEnrollment([]), courseId: 'invalid', isInvalid: true },
+      { ...mkEnrollment([]), courseId: 'unchanged' },
+      { ...mkEnrollment([]), courseId: 'changed' },
+      { ...mkEnrollment([]), courseId: 'both', isInvalid: true },
+    ]
+    const sectionChanges = new Map<string, []>([
+      ['changed', []],
+      ['both', []],
+    ])
+
+    expect(getChangedCourseIds(enrollments, sectionChanges)).toEqual(['invalid', 'changed', 'both'])
+  })
+})
 
 describe('sectionsOverlapInTime', () => {
   it('reports only real meeting overlaps', () => {

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -7,7 +7,6 @@ import {
   diffEnrollment,
   recordSeenSections,
   diffSectionDetail,
-  matchChangedMeeting,
   sectionsOverlapInTime,
   checkSectionConflict,
   hasConflictFreeEnrollment,
@@ -577,28 +576,5 @@ describe('diffSectionDetail', () => {
     expect(detail.rows).toHaveLength(1)
     expect(detail.rows[0].status).toBe('unchanged')
     expect(detail.languageChanged).toBe(true)
-  })
-})
-
-describe('matchChangedMeeting', () => {
-  const changed = [
-    {
-      current: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
-      before: { time: 'Mo 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
-      fields: { time: true, location: false, instructor: false },
-    },
-  ]
-
-  it('matches a raw meeting to its change entry after normalization', () => {
-    const meeting = mkMeeting({ time: 'We 9AM - 10AM', location: 'Hum  314' }) // double space
-    expect(matchChangedMeeting(meeting, changed)).toBe(changed[0])
-  })
-
-  it('returns undefined for a meeting not in the changed list', () => {
-    expect(matchChangedMeeting(mkMeeting({ time: 'Mo 9AM - 10AM' }), changed)).toBeUndefined()
-  })
-
-  it('returns undefined for an empty changed list', () => {
-    expect(matchChangedMeeting(mkMeeting({}), [])).toBeUndefined()
   })
 })

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -407,20 +407,26 @@ describe('recordSeenSections', () => {
 })
 
 describe('diffSectionDetail', () => {
-  it('reports no changed meetings and no language change when before matches current', () => {
+  it('returns unchanged live rows and no language change when before matches current', () => {
     const now = mkSection('1', [mkMeeting({})], 'English only')
     const detail = diffSectionDetail(now, sig(now))
-    expect(detail.changedMeetings).toHaveLength(0)
+    expect(detail.rows).toEqual([
+      {
+        status: 'unchanged',
+        meeting: { time: 'We 2:30PM - 5:15PM', location: 'Hum 314', instructor: 'Staff' },
+      },
+    ])
     expect(detail.languageChanged).toBe(false)
   })
 
-  it('pairs a changed meeting with its previous value and pinpoints the field', () => {
+  it('pairs an equal-count change without also returning a removed row', () => {
     const before = mkSection('1', [mkMeeting({ time: 'Mo 9AM - 10AM' })])
     const now = mkSection('1', [mkMeeting({ time: 'We 9AM - 10AM' })])
     const detail = diffSectionDetail(now, sig(before))
-    expect(detail.changedMeetings).toEqual([
+    expect(detail.rows).toEqual([
       {
-        current: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+        status: 'changed',
+        meeting: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
         before: { time: 'Mo 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
         fields: { time: true, location: false, instructor: false },
       },
@@ -435,7 +441,7 @@ describe('diffSectionDetail', () => {
       mkMeeting({ time: 'We 9AM - 10AM', location: 'T.C. Cheng 208', instructors: 'Prof Chen' }),
     ])
     const detail = diffSectionDetail(now, sig(before))
-    expect(detail.changedMeetings[0].fields).toEqual({
+    expect(detail.rows[0].fields).toEqual({
       time: true,
       location: true,
       instructor: true,
@@ -452,14 +458,18 @@ describe('diffSectionDetail', () => {
       mkMeeting({ time: 'Th 9AM - 10AM' }),
     ])
     const detail = diffSectionDetail(now, sig(before))
-    expect(detail.changedMeetings).toHaveLength(1)
-    expect(detail.changedMeetings[0].current.time).toBe('Th 9AM - 10AM')
-    expect(detail.changedMeetings[0].before!.time).toBe('We 9AM - 10AM')
-    expect(detail.changedMeetings[0].fields).toEqual({
-      time: true,
-      location: false,
-      instructor: false,
-    })
+    expect(detail.rows).toEqual([
+      {
+        status: 'unchanged',
+        meeting: { time: 'Mo 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'changed',
+        meeting: { time: 'Th 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+        before: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+        fields: { time: true, location: false, instructor: false },
+      },
+    ])
   })
 
   it('pairs by appearance order when several meetings change at once (same count)', () => {
@@ -472,30 +482,100 @@ describe('diffSectionDetail', () => {
       mkMeeting({ time: 'Th 9AM - 10AM' }),
     ])
     const detail = diffSectionDetail(now, sig(before))
-    expect(detail.changedMeetings.map((c) => [c.current.time, c.before!.time])).toEqual([
+    expect(detail.rows.map((row) => [row.meeting.time, row.before!.time])).toEqual([
       ['Tu 9AM - 10AM', 'Mo 9AM - 10AM'],
       ['Th 9AM - 10AM', 'We 9AM - 10AM'],
     ])
+    expect(detail.rows.every((row) => row.status === 'changed')).toBe(true)
   })
 
-  it('leaves before/fields undefined for an added meeting (counts differ, no pairing)', () => {
+  it('tags an unpaired new meeting as added', () => {
     const before = mkSection('1', [mkMeeting({ time: 'Mo 9AM - 10AM' })])
     const now = mkSection('1', [
       mkMeeting({ time: 'Mo 9AM - 10AM' }),
       mkMeeting({ time: 'We 9AM - 10AM' }),
     ])
     const detail = diffSectionDetail(now, sig(before))
-    expect(detail.changedMeetings).toHaveLength(1)
-    expect(detail.changedMeetings[0].current.time).toBe('We 9AM - 10AM')
-    expect(detail.changedMeetings[0].before).toBeUndefined()
-    expect(detail.changedMeetings[0].fields).toBeUndefined()
+    expect(detail.rows).toEqual([
+      {
+        status: 'unchanged',
+        meeting: { time: 'Mo 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'added',
+        meeting: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+    ])
   })
 
-  it('reports a language-only change with no changed meetings', () => {
+  it('appends a removed meeting after the remaining live rows', () => {
+    const before = mkSection('1', [
+      mkMeeting({ time: 'Mo 9AM - 10AM', location: 'Science Centre 327' }),
+      mkMeeting({ time: 'We 9AM - 10AM' }),
+      mkMeeting({ time: 'Fr 9AM - 10AM' }),
+    ])
+    const now = mkSection('1', [
+      mkMeeting({ time: 'We 9AM - 10AM' }),
+      mkMeeting({ time: 'Fr 9AM - 10AM' }),
+    ])
+
+    expect(diffSectionDetail(now, sig(before)).rows).toEqual([
+      {
+        status: 'unchanged',
+        meeting: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'unchanged',
+        meeting: { time: 'Fr 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'removed',
+        meeting: {
+          time: 'Mo 9AM - 10AM',
+          location: 'Science Centre 327',
+          instructor: 'Staff',
+        },
+      },
+    ])
+  })
+
+  it('does not fabricate pairings when added and removed counts differ', () => {
+    const before = mkSection('1', [
+      mkMeeting({ time: 'Mo 9AM - 10AM' }),
+      mkMeeting({ time: 'We 9AM - 10AM' }),
+    ])
+    const now = mkSection('1', [
+      mkMeeting({ time: 'We 9AM - 10AM' }),
+      mkMeeting({ time: 'Th 9AM - 10AM' }),
+      mkMeeting({ time: 'Fr 9AM - 10AM' }),
+    ])
+
+    expect(diffSectionDetail(now, sig(before)).rows).toEqual([
+      {
+        status: 'unchanged',
+        meeting: { time: 'We 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'added',
+        meeting: { time: 'Th 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'added',
+        meeting: { time: 'Fr 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+      {
+        status: 'removed',
+        meeting: { time: 'Mo 9AM - 10AM', location: 'Hum 314', instructor: 'Staff' },
+      },
+    ])
+  })
+
+  it('reports a language-only change with unchanged meeting rows', () => {
     const before = mkSection('1', [mkMeeting({})], 'English only')
     const now = mkSection('1', [mkMeeting({})], 'Putonghua and English')
     const detail = diffSectionDetail(now, sig(before))
-    expect(detail.changedMeetings).toHaveLength(0)
+    expect(detail.rows).toHaveLength(1)
+    expect(detail.rows[0].status).toBe('unchanged')
     expect(detail.languageChanged).toBe(true)
   })
 })

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -15,7 +15,6 @@ import type {
   SectionChange,
   SectionSignature,
   SectionMeetingSignature,
-  SectionMeetingChange,
   SectionDiffDetail,
   MeetingRow,
 } from './types'
@@ -583,15 +582,6 @@ export function diffSectionDetail(
   }
 
   return { rows, languageChanged: before.language !== current.language }
-}
-
-// Finds the change entry for a raw (as-rendered) meeting, or undefined if it didn't change.
-export function matchChangedMeeting(
-  meeting: InternalMeeting,
-  changedMeetings: SectionMeetingChange[]
-): SectionMeetingChange | undefined {
-  const row = meetingRow(meeting)
-  return changedMeetings.find((c) => sameMeeting(c.current, row))
 }
 
 /**

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -543,6 +543,16 @@ export function diffEnrollment(enrollment: CourseEnrollment): SectionChange[] {
   return changes
 }
 
+/** Course ids needing attention, in cart order and without duplicates. */
+export function getChangedCourseIds(
+  enrollments: CourseEnrollment[],
+  sectionChanges?: ReadonlyMap<string, SectionChange[]>
+): string[] {
+  return enrollments
+    .filter((enrollment) => enrollment.isInvalid || sectionChanges?.has(enrollment.courseId))
+    .map((enrollment) => enrollment.courseId)
+}
+
 // Rebuilds lastSeenSections for the selected sections, pruning de-selected ids.
 // onlyMissing seeds only new entries (add/sync); false overwrites all (dismiss).
 export function recordSeenSections(

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -17,6 +17,7 @@ import type {
   SectionMeetingSignature,
   SectionDiffDetail,
   MeetingRow,
+  InvalidEnrollmentState,
 } from './types'
 import { SECTION_TYPE_CONFIG } from './types'
 import { SCHEDULE_DATA_VERSION } from './constants'
@@ -452,6 +453,7 @@ export function updateExistingEnrollment(
     selectedSections,
     isInvalid: false,
     invalidReason: undefined,
+    lastSeenInvalidState: undefined,
     lastSynced: new Date(),
   }
 }
@@ -549,8 +551,43 @@ export function getChangedCourseIds(
   sectionChanges?: ReadonlyMap<string, SectionChange[]>
 ): string[] {
   return enrollments
-    .filter((enrollment) => enrollment.isInvalid || sectionChanges?.has(enrollment.courseId))
+    .filter(
+      (enrollment) => hasUnseenInvalidChange(enrollment) || sectionChanges?.has(enrollment.courseId)
+    )
     .map((enrollment) => enrollment.courseId)
+}
+
+function getInvalidEnrollmentState(
+  enrollment: CourseEnrollment
+): InvalidEnrollmentState | undefined {
+  if (!enrollment.isInvalid) return undefined
+  return {
+    reason: enrollment.invalidReason ?? 'Course data is outdated',
+    sectionIds: enrollment.selectedSections
+      .filter((section) => section.isInvalid)
+      .map((section) => section.id)
+      .sort(),
+  }
+}
+
+function sameInvalidEnrollmentState(
+  left: InvalidEnrollmentState,
+  right: InvalidEnrollmentState
+): boolean {
+  return (
+    left.reason === right.reason &&
+    left.sectionIds.length === right.sectionIds.length &&
+    left.sectionIds.every((id, index) => id === right.sectionIds[index])
+  )
+}
+
+export function hasUnseenInvalidChange(enrollment: CourseEnrollment): boolean {
+  const current = getInvalidEnrollmentState(enrollment)
+  if (!current) return false
+  return (
+    !enrollment.lastSeenInvalidState ||
+    !sameInvalidEnrollmentState(current, enrollment.lastSeenInvalidState)
+  )
 }
 
 // Rebuilds lastSeenSections for the selected sections, pruning de-selected ids.
@@ -568,6 +605,14 @@ export function recordSeenSections(
         : sectionSignature(section)
   }
   return { ...enrollment, lastSeenSections: next }
+}
+
+/** Acknowledge both section-detail changes and the current invalid status. */
+export function recordSeenChanges(enrollment: CourseEnrollment): CourseEnrollment {
+  return {
+    ...recordSeenSections(enrollment, { onlyMissing: false }),
+    lastSeenInvalidState: getInvalidEnrollmentState(enrollment),
+  }
 }
 
 // Detection above compares meeting positions to decide whether a section changed. Detail

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -927,25 +927,6 @@ export function formatSyncTimestamp(date: Date): string {
 }
 
 /**
- * Group meetings by time + location + instructor to show unique meetings
- * This consolidates duplicate meetings that occur at the same time/place with same instructor
- */
-export function getUniqueMeetings(meetings: InternalMeeting[]): InternalMeeting[] {
-  const meetingGroups = new Map<string, InternalMeeting[]>()
-
-  meetings.forEach((meeting) => {
-    const key = `${meeting?.time || 'TBA'}-${meeting?.location || 'TBA'}-${meeting?.instructors || 'TBA'}`
-    if (!meetingGroups.has(key)) {
-      meetingGroups.set(key, [])
-    }
-    meetingGroups.get(key)!.push(meeting)
-  })
-
-  // Return first meeting from each group (they're identical for display purposes)
-  return Array.from(meetingGroups.values()).map((group) => group[0])
-}
-
-/**
  * Format time string for compact display: "Tu 12:30PM - 2:15PM" → "Tu 12:30-14:15"
  */
 export function formatTimeCompact(timeStr: string): string {

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -471,15 +471,26 @@ export function markCourseUnavailable(
   }
 }
 
+// JSON.stringify writes Dates as ISO strings; revive them here so the rest of the app
+// only ever sees Date. Keep this in sync with any future Date field on CourseEnrollment.
+function reviveEnrollmentDates(enrollments: CourseEnrollment[]): CourseEnrollment[] {
+  return enrollments.map((enrollment) =>
+    typeof enrollment.lastSynced === 'string'
+      ? { ...enrollment, lastSynced: new Date(enrollment.lastSynced) }
+      : enrollment
+  )
+}
+
 // Enrollments to load from a persisted schedule blob, or null to wipe it. Known versions
 // load as-is — schema changes so far are additive — unknown/newer versions don't.
 export function readStoredEnrollments(parsed: unknown): CourseEnrollment[] | null {
-  if (Array.isArray(parsed)) return parsed as CourseEnrollment[] // legacy pre-version format
+  if (Array.isArray(parsed)) return reviveEnrollmentDates(parsed as CourseEnrollment[]) // legacy pre-version format
   if (parsed && typeof parsed === 'object') {
     const version = (parsed as { version?: unknown }).version
     if (typeof version === 'number' && version >= 1 && version <= SCHEDULE_DATA_VERSION) {
-      return ((parsed as { enrollments?: CourseEnrollment[] }).enrollments ??
-        []) as CourseEnrollment[]
+      return reviveEnrollmentDates(
+        ((parsed as { enrollments?: CourseEnrollment[] }).enrollments ?? []) as CourseEnrollment[]
+      )
     }
   }
   return null
@@ -898,8 +909,8 @@ export function getDeterministicColor(courseCode: string): string {
   return DETERMINISTIC_COLORS[Math.abs(hash) % DETERMINISTIC_COLORS.length]
 }
 
-export function formatSyncTimestamp(timestamp: Date | string): string {
-  const date = timestamp instanceof Date ? timestamp : new Date(timestamp)
+export function formatSyncTimestamp(date: Date): string {
+  // Guards against a corrupt persisted value revived into an invalid Date.
   if (Number.isNaN(date.getTime())) return 'Unknown'
 
   const formattedDate = date.toLocaleDateString('en-US', {

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -16,6 +16,8 @@ import type {
   SectionSignature,
   SectionMeetingSignature,
   SectionMeetingChange,
+  SectionDiffDetail,
+  MeetingRow,
 } from './types'
 import { SECTION_TYPE_CONFIG } from './types'
 import { SCHEDULE_DATA_VERSION } from './constants'
@@ -546,33 +548,41 @@ export function recordSeenSections(
   return { ...enrollment, lastSeenSections: next }
 }
 
-// Each changed meeting paired to its previous value, so the cart can highlight the exact
-// field that moved. Meetings are paired positionally only when the count is unchanged
-// (|added| === |removed|); a differing count means one was added/removed outright, so it's
-// left unpaired (before/fields undefined) and the caller highlights the whole row.
+// Detection above compares meeting positions to decide whether a section changed. Detail
+// classification instead uses content-based set differences so rows shifted by a removal
+// remain unchanged. Equal added/removed counts retain the existing positional pairing.
 export function diffSectionDetail(
   section: InternalSection,
   before: SectionSignature
-): { changedMeetings: SectionMeetingChange[]; languageChanged: boolean } {
+): SectionDiffDetail {
   const current = sectionSignature(section)
   const added = current.meetings.filter((m) => !before.meetings.some((b) => sameMeeting(b, m)))
   const removed = before.meetings.filter((b) => !current.meetings.some((m) => sameMeeting(m, b)))
   const paired = added.length === removed.length
-  const changedMeetings: SectionMeetingChange[] = added.map((meeting, i) => {
-    const previous = paired ? removed[i] : undefined
+
+  const rows: MeetingRow[] = current.meetings.map((meeting) => {
+    const addedIndex = added.findIndex((candidate) => sameMeeting(candidate, meeting))
+    if (addedIndex === -1) return { status: 'unchanged', meeting }
+    if (!paired) return { status: 'added', meeting }
+
+    const previous = removed[addedIndex]
     return {
-      current: meeting,
+      status: 'changed',
+      meeting,
       before: previous,
-      fields: previous
-        ? {
-            time: previous.time !== meeting.time,
-            location: previous.location !== meeting.location,
-            instructor: previous.instructor !== meeting.instructor,
-          }
-        : undefined,
+      fields: {
+        time: previous.time !== meeting.time,
+        location: previous.location !== meeting.location,
+        instructor: previous.instructor !== meeting.instructor,
+      },
     }
   })
-  return { changedMeetings, languageChanged: before.language !== current.language }
+
+  if (!paired) {
+    rows.push(...removed.map((meeting): MeetingRow => ({ status: 'removed', meeting })))
+  }
+
+  return { rows, languageChanged: before.language !== current.language }
 }
 
 // Finds the change entry for a raw (as-rendered) meeting, or undefined if it didn't change.

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -456,6 +456,19 @@ export function updateExistingEnrollment(
   }
 }
 
+/** Preserve an unavailable course in the cart and record when fresh data confirmed it. */
+export function markCourseUnavailable(
+  enrollment: CourseEnrollment,
+  syncedAt: Date
+): CourseEnrollment {
+  return {
+    ...enrollment,
+    isInvalid: true,
+    invalidReason: 'Course no longer available',
+    lastSynced: syncedAt,
+  }
+}
+
 // Enrollments to load from a persisted schedule blob, or null to wipe it. Known versions
 // load as-is — schema changes so far are additive — unknown/newer versions don't.
 export function readStoredEnrollments(parsed: unknown): CourseEnrollment[] | null {

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -830,6 +830,23 @@ export function getDeterministicColor(courseCode: string): string {
   return DETERMINISTIC_COLORS[Math.abs(hash) % DETERMINISTIC_COLORS.length]
 }
 
+export function formatSyncTimestamp(timestamp: Date | string): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+
+  const formattedDate = date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+  const formattedTime = date.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+  return `${formattedDate} ${formattedTime}`
+}
+
 /**
  * Group meetings by time + location + instructor to show unique meetings
  * This consolidates duplicate meetings that occur at the same time/place with same instructor

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -91,15 +91,6 @@ export interface SectionDiffDetail {
   languageChanged: boolean
 }
 
-// One changed meeting, paired to its previous value when meetings can be matched 1:1
-// (see diffSectionDetail). `before`/`fields` are absent when a meeting was added with no
-// counterpart to pair against. `fields` marks which of time/location/instructor differ.
-export interface SectionMeetingChange {
-  current: SectionMeetingSignature
-  before?: SectionMeetingSignature
-  fields?: { time: boolean; location: boolean; instructor: boolean }
-}
-
 export interface SectionAvailability {
   capacity: number
   enrolled: number

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -77,6 +77,20 @@ export interface SectionChange {
   after: SectionSignature
 }
 
+export type MeetingChangeStatus = 'unchanged' | 'added' | 'changed' | 'removed'
+
+export interface MeetingRow {
+  status: MeetingChangeStatus
+  meeting: SectionMeetingSignature
+  before?: SectionMeetingSignature
+  fields?: { time: boolean; location: boolean; instructor: boolean }
+}
+
+export interface SectionDiffDetail {
+  rows: MeetingRow[]
+  languageChanged: boolean
+}
+
 // One changed meeting, paired to its previous value when meetings can be matched 1:1
 // (see diffSectionDetail). `before`/`fields` are absent when a meeting was added with no
 // counterpart to pair against. `fields` marks which of time/location/instructor differ.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -137,7 +137,7 @@ export interface CourseEnrollment {
   // Sync status fields
   isInvalid?: boolean // True if course/sections no longer exist
   invalidReason?: string // Human-readable reason for invalidity
-  lastSynced?: Date // When this enrollment was last synced with fresh data
+  lastSynced?: Date | string // Date in memory; ISO string after localStorage persistence
   // Per-section sectionSignature the user last saw, keyed by section id. Not rendered
   // directly — only used to detect changes. Missing entry = adopt current section.
   lastSeenSections?: Record<string, SectionSignature>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -142,7 +142,7 @@ export interface CourseEnrollment {
   // Sync status fields
   isInvalid?: boolean // True if course/sections no longer exist
   invalidReason?: string // Human-readable reason for invalidity
-  lastSynced?: Date | string // Date in memory; ISO string after localStorage persistence
+  lastSynced?: Date // Persisted as an ISO string; revived to Date in readStoredEnrollments
   // Per-section sectionSignature the user last saw, keyed by section id. Not rendered
   // directly — only used to detect changes. Missing entry = adopt current section.
   lastSeenSections?: Record<string, SectionSignature>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -127,6 +127,11 @@ export const SECTION_TYPE_CONFIG = {
 // Derive the type from the config keys - automatically stays in sync
 export type SectionType = keyof typeof SECTION_TYPE_CONFIG
 
+export interface InvalidEnrollmentState {
+  reason: string
+  sectionIds: string[]
+}
+
 // Course enrollment using clean internal types
 export interface CourseEnrollment {
   courseId: string
@@ -141,6 +146,9 @@ export interface CourseEnrollment {
   // Per-section sectionSignature the user last saw, keyed by section id. Not rendered
   // directly — only used to detect changes. Missing entry = adopt current section.
   lastSeenSections?: Record<string, SectionSignature>
+  // Invalid status the user last acknowledged. Kept separate from isInvalid because
+  // dismissing a notification must not make unavailable data appear valid.
+  lastSeenInvalidState?: InvalidEnrollmentState
 }
 
 // Calendar event using clean internal types


### PR DESCRIPTION
<img width="275" height="269" alt="image" src="https://github.com/user-attachments/assets/67ded868-3a53-443c-9a30-1662a71c746c" />

<img width="248" height="377" alt="image" src="https://github.com/user-attachments/assets/4e0bc77a-e174-46be-a8af-54a30d27ca31" />

aware of section removal now also blocking the whole card, can do it in a way with better UX, but maybe not in this PR
<img width="231" height="131" alt="image" src="https://github.com/user-attachments/assets/981f9611-8ba6-40e0-a3d1-18b9ba376bd5" />
