### PR TITLE
fix: pin the timezone to avoid hydration error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 .agents/
 .claude/
 skills-lock.json
+.playwright-mcp/
 
 # Verbose generated logs. Keep root-level summary files in logs/ tracked.
 /logs/publish/

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -54,7 +54,7 @@ Every course file carries `metadata.schema_version` (`SCHEMA_VERSION` in [script
 
 ### Freshness
 
-Each data directory holds a `_scraped_at.txt`: when the scrape that wrote it started. Publishing reads those into [scrape-times.ts](../web/src/lib/generated/scrape-times.ts) for the app's "Last Data Sync".
+Each data directory holds a `_scraped_at.txt`: when the scrape that wrote it started. Publishing reads those into [scrape-times.ts](../web/src/lib/generated/scrape-times.ts) for the app's "Last Data Sync", which always displays them in HKT — the page is prerendered, so a zone that varies by machine would break hydration.
 
 Only full scrapes write them, and only for the directories they produced — so a year CUHK drops keeps its own time ([why](decisions.md#stamp-each-data-directory-with-its-scrape-time)).
 

--- a/web/src/components/CourseSearch.tsx
+++ b/web/src/components/CourseSearch.tsx
@@ -943,7 +943,10 @@ export default function CourseSearch({
                     </span>
                     <span className="whitespace-nowrap">
                       Last Data Sync:{' '}
-                      {formatSyncTimestamp(new Date(SCRAPED_AT_BY_YEAR[selectedYear]))}
+                      {/* dateTime carries the unambiguous instant for machines and screen readers. */}
+                      <time dateTime={SCRAPED_AT_BY_YEAR[selectedYear]}>
+                        {formatSyncTimestamp(new Date(SCRAPED_AT_BY_YEAR[selectedYear]))}
+                      </time>
                     </span>
                   </div>
                 </>

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -11,6 +11,11 @@ export const NOTICE_IMAGE_LOADED_EVENT = 'mobile-notice-image-loaded'
 // Data versioning
 export const SCHEDULE_DATA_VERSION = 3
 
+// CUHK's timezone. Pin it wherever a date is formatted or parsed: the page is
+// prerendered at build time, so reading the ambient zone instead would make the
+// build machine's output disagree with the browser's and break hydration.
+export const HONG_KONG_TIMEZONE = 'Asia/Hong_Kong'
+
 // Default selected term. Bump on rollover manually for now.
 export const DEFAULT_CURRENT_TERM = '2026-27 Term 1'
 

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -16,6 +16,12 @@ export const SCHEDULE_DATA_VERSION = 3
 // build machine's output disagree with the browser's and break hydration.
 export const HONG_KONG_TIMEZONE = 'Asia/Hong_Kong'
 
+// Suffix for times shown in that zone. Kept next to it so the two stay in step.
+// Only CLDR's en-HK locale carries "HKT" — other English locales fall back to
+// "GMT+8" — so a literal keeps the build and the browser in agreement whatever
+// locale data each one ships.
+export const HONG_KONG_TIMEZONE_LABEL = 'HKT'
+
 // Default selected term. Bump on rollover manually for now.
 export const DEFAULT_CURRENT_TERM = '2026-27 Term 1'
 

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -29,9 +29,25 @@ import type {
 } from './types'
 
 describe('formatSyncTimestamp', () => {
+  // Absolute instants, so these assertions hold under any TZ the test runs in.
   it('formats in 24-hour time and falls back to Unknown for an invalid Date', () => {
-    expect(formatSyncTimestamp(new Date(2026, 6, 14, 21, 27))).toBe('Jul 14, 2026 21:27')
+    expect(formatSyncTimestamp(new Date('2026-07-14T13:27:00Z'))).toBe('Jul 14, 2026 21:27')
     expect(formatSyncTimestamp(new Date('corrupt'))).toBe('Unknown')
+  })
+
+  // Guards the hydration fix: the build machine prerenders this string and the
+  // visitor's browser rehydrates it, so it must not depend on the ambient zone.
+  // The instant lands on a different date in UTC than in Hong Kong.
+  it('formats in Hong Kong time regardless of the ambient timezone', () => {
+    const originalTimezone = process.env.TZ
+    try {
+      for (const timezone of ['UTC', 'America/New_York', 'Asia/Hong_Kong']) {
+        process.env.TZ = timezone
+        expect(formatSyncTimestamp(new Date('2026-07-17T16:05:00Z'))).toBe('Jul 18, 2026 00:05')
+      }
+    } finally {
+      process.env.TZ = originalTimezone
+    }
   })
 })
 

--- a/web/src/lib/courseUtils.test.ts
+++ b/web/src/lib/courseUtils.test.ts
@@ -31,7 +31,7 @@ import type {
 describe('formatSyncTimestamp', () => {
   // Absolute instants, so these assertions hold under any TZ the test runs in.
   it('formats in 24-hour time and falls back to Unknown for an invalid Date', () => {
-    expect(formatSyncTimestamp(new Date('2026-07-14T13:27:00Z'))).toBe('Jul 14, 2026 21:27')
+    expect(formatSyncTimestamp(new Date('2026-07-14T13:27:00Z'))).toBe('Jul 14, 2026 21:27 HKT')
     expect(formatSyncTimestamp(new Date('corrupt'))).toBe('Unknown')
   })
 
@@ -43,7 +43,7 @@ describe('formatSyncTimestamp', () => {
     try {
       for (const timezone of ['UTC', 'America/New_York', 'Asia/Hong_Kong']) {
         process.env.TZ = timezone
-        expect(formatSyncTimestamp(new Date('2026-07-17T16:05:00Z'))).toBe('Jul 18, 2026 00:05')
+        expect(formatSyncTimestamp(new Date('2026-07-17T16:05:00Z'))).toBe('Jul 18, 2026 00:05 HKT')
       }
     } finally {
       process.env.TZ = originalTimezone

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -20,7 +20,7 @@ import type {
   InvalidEnrollmentState,
 } from './types'
 import { SECTION_TYPE_CONFIG } from './types'
-import { HONG_KONG_TIMEZONE, SCHEDULE_DATA_VERSION } from './constants'
+import { HONG_KONG_TIMEZONE, HONG_KONG_TIMEZONE_LABEL, SCHEDULE_DATA_VERSION } from './constants'
 import { createEvents } from 'ics'
 import moment from 'moment-timezone'
 
@@ -1055,7 +1055,7 @@ export function formatSyncTimestamp(date: Date): string {
     hourCycle: 'h23',
     timeZone: HONG_KONG_TIMEZONE,
   })
-  return `${formattedDate} ${formattedTime}`
+  return `${formattedDate} ${formattedTime} ${HONG_KONG_TIMEZONE_LABEL}`
 }
 
 /**

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -20,7 +20,7 @@ import type {
   InvalidEnrollmentState,
 } from './types'
 import { SECTION_TYPE_CONFIG } from './types'
-import { SCHEDULE_DATA_VERSION } from './constants'
+import { HONG_KONG_TIMEZONE, SCHEDULE_DATA_VERSION } from './constants'
 import { createEvents } from 'ics'
 import moment from 'moment-timezone'
 
@@ -1047,11 +1047,13 @@ export function formatSyncTimestamp(date: Date): string {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: HONG_KONG_TIMEZONE,
   })
   const formattedTime = date.toLocaleTimeString('en-GB', {
     hour: '2-digit',
     minute: '2-digit',
-    hour12: false,
+    hourCycle: 'h23',
+    timeZone: HONG_KONG_TIMEZONE,
   })
   return `${formattedDate} ${formattedTime}`
 }
@@ -1766,7 +1768,7 @@ function convertToHongKongUTC(date: Date, hours: number, minutes: number): momen
   const timeString = `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')} ${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`
 
   // Parse as Hong Kong time and convert to UTC
-  return moment.tz(timeString, 'Asia/Hong_Kong').utc()
+  return moment.tz(timeString, HONG_KONG_TIMEZONE).utc()
 }
 
 /**


### PR DESCRIPTION
"Last Data Sync" read the ambient timezone, so the prerendered HTML carried the build machine's UTC rendering while browsers hydrated it as local time. React reported the differing text as a hydration error (#418) and recovered by re-rendering, so users saw the correct time — only PostHog noticed.

Pin the zone at both format sites, and label the result HKT so visitors abroad don't read it as their own local time.