### PR TITLE
ci: add Dependabot version updates for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Version-update PRs. Security updates run separately from repo settings.
+# Minor/patch grouped into one weekly PR; majors come separately for a closer look.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm # root tooling (Prettier)
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Only security updates were configured (via repo settings), so routine bumps weren't proposed. Add weekly version updates for the web app and root tooling, grouping minor/patch into one PR.