### PR TITLE
style(calendar): improve meeting card readability

### DIFF
--- a/docs/components/weekly-calendar.md
+++ b/docs/components/weekly-calendar.md
@@ -12,6 +12,7 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 - **Minimum day width:** day columns share available space but stop shrinking at 128px; narrower viewports scroll horizontally.
 - **Bounded wrapping:** locations and instructors may use a second line only when the meeting duration already provides enough card height.
 - **Single scroll container:** one element owns both axes to avoid duplicate horizontal scrollbars.
+- **Screenshot width:** exports use at least 800px and expand for seven-day calendars, independent of viewport width.
 - **Z-index ladder:** sticky day header `z-50`, selected card `z-40`, conflict stacks `z-2x`, dropdown menus `z-[60]` (must clear the sticky header). Changing one requires checking the others.
 
 ## ICS Export

--- a/docs/components/weekly-calendar.md
+++ b/docs/components/weekly-calendar.md
@@ -10,6 +10,7 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 
 - **Dynamic hour height:** the grid is scaled so a 45-minute event (`MINIMUM_COURSE_DURATION_MINUTES`, the shortest CUHK class) exactly fits the rows enabled in the display config. Hardcoding card or slot heights breaks the guarantee that the shortest class can show every enabled row.
 - **Minimum day width:** day columns share available space but stop shrinking at 128px; narrower viewports scroll horizontally.
+- **Bounded wrapping:** locations and instructors may use a second line only when the meeting duration already provides enough card height.
 - **Single scroll container:** one element owns both axes to avoid duplicate horizontal scrollbars.
 - **Z-index ladder:** sticky day header `z-50`, selected card `z-40`, conflict stacks `z-2x`, dropdown menus `z-[60]` (must clear the sticky header). Changing one requires checking the others.
 
@@ -29,6 +30,6 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 
 ## Known Limitations
 
-- Card fields truncate to one line. Wrapping would require variable card heights, particularly for instructor lists.
+- Fields in 45-minute cards stay single-line; wrapped fields clamp after two lines.
 - Desktop and mobile header layouts duplicate the ICS split-button markup within the file.
 - User dialogs are native `alert`/`confirm` rather than styled modals (deliberate simplicity).

--- a/docs/components/weekly-calendar.md
+++ b/docs/components/weekly-calendar.md
@@ -9,6 +9,8 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 ## Layout
 
 - **Dynamic hour height:** the grid is scaled so a 45-minute event (`MINIMUM_COURSE_DURATION_MINUTES`, the shortest CUHK class) exactly fits the rows enabled in the display config. Hardcoding card or slot heights breaks the guarantee that the shortest class can show every enabled row.
+- **Minimum day width:** day columns share available space but stop shrinking at 128px; narrower viewports scroll horizontally.
+- **Single scroll container:** one element owns both axes to avoid duplicate horizontal scrollbars.
 - **Z-index ladder:** sticky day header `z-50`, selected card `z-40`, conflict stacks `z-2x`, dropdown menus `z-[60]` (must clear the sticky header). Changing one requires checking the others.
 
 ## ICS Export
@@ -27,6 +29,6 @@ Only non-obvious constraints and rationale are documented here; the code is the 
 
 ## Known Limitations
 
-- On small-width devices, event card text truncates; the grid keeps `MINIMUM_CALENDAR_WIDTH` and scrolls horizontally instead of adapting to narrow columns. Low priority.
+- Card fields truncate to one line. Wrapping would require variable card heights, particularly for instructor lists.
 - Desktop and mobile header layouts duplicate the ICS split-button markup within the file.
 - User dialogs are native `alert`/`confirm` rather than styled modals (deliberate simplicity).

--- a/web/src/components/WeeklyCalendar.tsx
+++ b/web/src/components/WeeklyCalendar.tsx
@@ -20,8 +20,9 @@ import {
   DEFAULT_CALENDAR_CONFIG,
   CALENDAR_LAYOUT_CONSTANTS,
   TEXT_STYLES,
-  ROW_HEIGHTS,
   MINIMUM_COURSE_DURATION_MINUTES,
+  calculateReferenceCardHeight,
+  getCardTextLineLimits,
   getDayIndex,
   getRequiredDays,
   getGridColumns,
@@ -31,23 +32,6 @@ import {
 } from '@/lib/calendarConfig'
 import type { CalendarEvent, CourseEnrollment, InternalSection, InternalMeeting } from '@/lib/types'
 import { analytics } from '@/lib/analytics'
-
-/**
- * Calculate the total height needed for a course card based on display configuration
- */
-const calculateReferenceCardHeight = (displayConfig: CalendarDisplayConfig): number => {
-  let totalHeight = ROW_HEIGHTS.COURSE_CODE // Course code + section type always shown
-
-  if (displayConfig.showTitle) totalHeight += ROW_HEIGHTS.TITLE
-  if (displayConfig.showTime) totalHeight += ROW_HEIGHTS.TIME
-  if (displayConfig.showLocation) totalHeight += ROW_HEIGHTS.LOCATION
-  if (displayConfig.showInstructor) totalHeight += ROW_HEIGHTS.INSTRUCTOR
-
-  // Add padding (4px top + 4px bottom)
-  totalHeight += CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING * 2
-
-  return totalHeight
-}
 
 /**
  * Calculate dynamic hour height based on minimum course duration requirements
@@ -765,6 +749,7 @@ export default function WeeklyCalendar({
                           )
                           const isConflicted = group.length > 1
                           const isSelected = selectedEnrollment === event.enrollmentId
+                          const textLineLimits = getCardTextLineLimits(height, localDisplayConfig)
 
                           // Stacking for conflicts
                           const stackOffset = isConflicted
@@ -867,13 +852,21 @@ export default function WeeklyCalendar({
                               )}
 
                               {localDisplayConfig.showLocation && (
-                                <div className={`${TEXT_STYLES.LOCATION} truncate`}>
+                                <div
+                                  className={`${TEXT_STYLES.LOCATION} ${
+                                    textLineLimits.location === 2 ? 'line-clamp-2' : 'truncate'
+                                  }`}
+                                >
                                   {event.location}
                                 </div>
                               )}
 
                               {localDisplayConfig.showInstructor && (
-                                <div className={`${TEXT_STYLES.INSTRUCTOR} truncate`}>
+                                <div
+                                  className={`${TEXT_STYLES.INSTRUCTOR} ${
+                                    textLineLimits.instructor === 2 ? 'line-clamp-2' : 'truncate'
+                                  }`}
+                                >
                                   {event.instructors
                                     ? formatInstructorsCompact(event.instructors)
                                     : 'TBA'}

--- a/web/src/components/WeeklyCalendar.tsx
+++ b/web/src/components/WeeklyCalendar.tsx
@@ -226,7 +226,9 @@ export default function WeeklyCalendar({
         '[data-screenshot="unscheduled"]'
       ) as HTMLElement | null
 
-      await captureCalendarScreenshot(calendarRef.current, unscheduledElement, selectedTerm)
+      await captureCalendarScreenshot(calendarRef.current, unscheduledElement, selectedTerm, {
+        minimumCalendarWidth,
+      })
       analytics.screenshotTaken()
     } catch (error) {
       console.error('Screenshot capture failed:', error)

--- a/web/src/components/WeeklyCalendar.tsx
+++ b/web/src/components/WeeklyCalendar.tsx
@@ -25,6 +25,7 @@ import {
   getDayIndex,
   getRequiredDays,
   getGridColumns,
+  getMinimumCalendarWidth,
   type CalendarDisplayConfig,
   type CalendarLayoutConfig,
 } from '@/lib/calendarConfig'
@@ -131,21 +132,21 @@ export default function WeeklyCalendar({
     canScrollDown: false,
   })
 
-  // Ref for capturing the calendar component
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const calendarRef = useRef<HTMLDivElement>(null)
 
   const updateScrollStateHandler = useCallback(() => {
-    if (!calendarRef.current) return
+    if (!scrollContainerRef.current) return
 
-    const { scrollTop, scrollHeight, clientHeight } = calendarRef.current
+    const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current
     const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
 
     // Auto-adjust if scrolled past the new bottom
     if (scrollTop > maxScrollTop) {
-      calendarRef.current.scrollTop = maxScrollTop
+      scrollContainerRef.current.scrollTop = maxScrollTop
     }
 
-    const currentScrollTop = calendarRef.current.scrollTop
+    const currentScrollTop = scrollContainerRef.current.scrollTop
     const tolerance = 1
     const significantScrollThreshold = 5
 
@@ -163,14 +164,17 @@ export default function WeeklyCalendar({
   }, [updateScrollStateHandler])
 
   const scrollToTopHandler = useCallback(() => {
-    if (calendarRef.current) {
-      calendarRef.current.scrollTo({ top: 0, behavior: 'smooth' })
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }, [])
 
   const scrollToBottomHandler = useCallback(() => {
-    if (calendarRef.current) {
-      calendarRef.current.scrollTo({ top: calendarRef.current.scrollHeight, behavior: 'smooth' })
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo({
+        top: scrollContainerRef.current.scrollHeight,
+        behavior: 'smooth',
+      })
     }
   }, [])
 
@@ -180,10 +184,10 @@ export default function WeeklyCalendar({
 
   // Update scroll indicators when content changes
   useEffect(() => {
-    if (!calendarRef.current) return
+    if (!scrollContainerRef.current) return
 
     const resizeObserver = new ResizeObserver(updateScrollStateHandler)
-    resizeObserver.observe(calendarRef.current)
+    resizeObserver.observe(scrollContainerRef.current)
 
     // Update immediately on config/events change
     updateScrollStateHandler()
@@ -193,12 +197,12 @@ export default function WeeklyCalendar({
 
   // Auto-scroll to selected event
   useEffect(() => {
-    if (!selectedEnrollment || !calendarRef.current) return
+    if (!selectedEnrollment || !scrollContainerRef.current) return
 
     const selectedElement = eventRefs.current.get(selectedEnrollment)
     if (!selectedElement) return
 
-    const container = calendarRef.current
+    const container = scrollContainerRef.current
     const elementTop = selectedElement.offsetTop
     const elementHeight = selectedElement.offsetHeight
     const containerHeight = container.clientHeight
@@ -382,6 +386,7 @@ export default function WeeklyCalendar({
   // Dynamic day detection - show weekends only when courses exist
   const days = getRequiredDays(events)
   const gridColumns = getGridColumns(days.length)
+  const minimumCalendarWidth = getMinimumCalendarWidth(days.length)
 
   // Calculate dynamic hour height based on display configuration
   const dynamicHourHeight = calculateDynamicHourHeight(
@@ -615,275 +620,273 @@ export default function WeeklyCalendar({
           </button>
         )}
 
-        {/* Mobile horizontal scroll wrapper */}
-        <div className="overflow-x-auto h-full">
+        <div
+          className="h-full max-h-[720px] overflow-auto"
+          ref={scrollContainerRef}
+          onScroll={handleScroll}
+        >
           <div
+            ref={calendarRef}
             className="h-full"
-            style={{ minWidth: `${CALENDAR_LAYOUT_CONSTANTS.MINIMUM_CALENDAR_WIDTH}px` }}
+            style={{ minWidth: `${minimumCalendarWidth}px` }}
           >
+            {/* Sticky Header Row */}
             <div
-              className="h-full max-h-[720px] overflow-y-auto"
-              ref={calendarRef}
-              onScroll={handleScroll}
+              className="grid border-gray-200 bg-white sticky top-0 z-50 shadow-xs"
+              style={{
+                gridTemplateColumns: gridColumns,
+                height: `${CALENDAR_LAYOUT_CONSTANTS.STICKY_HEADER_HEIGHT}px`,
+              }}
             >
-              {/* Sticky Header Row */}
-              <div
-                className="grid border-gray-200 bg-white sticky top-0 z-50 shadow-xs"
-                style={{
-                  gridTemplateColumns: gridColumns,
-                  height: `${CALENDAR_LAYOUT_CONSTANTS.STICKY_HEADER_HEIGHT}px`,
-                }}
-              >
-                <div className="h-full flex items-center justify-center text-xs font-medium text-gray-500 border-b border-r border-gray-200 flex-shrink-0 bg-white">
-                  Time
+              <div className="h-full flex items-center justify-center text-xs font-medium text-gray-500 border-b border-r border-gray-200 flex-shrink-0 bg-white">
+                Time
+              </div>
+              {days.map((day) => (
+                <div
+                  key={day}
+                  className="h-full flex items-center justify-center text-xs font-medium text-gray-700 border-b border-r border-gray-200 min-w-0 flex-1 bg-white"
+                >
+                  {day}
                 </div>
-                {days.map((day) => (
-                  <div
-                    key={day}
-                    className="h-full flex items-center justify-center text-xs font-medium text-gray-700 border-b border-r border-gray-200 min-w-0 flex-1 bg-white"
-                  >
-                    {day}
-                  </div>
-                ))}
+              ))}
+            </div>
+
+            {/* Calendar Content Grid */}
+            <div
+              className="grid"
+              style={{ gridTemplateColumns: gridColumns }}
+              onClick={(e) => {
+                const target = e.target as HTMLElement
+                const isEmptySpace = !target.closest('[data-course-card]')
+
+                if (isEmptySpace && onSelectEnrollment) {
+                  onSelectEnrollment(null)
+                }
+              }}
+            >
+              {/* Time column */}
+              <div className="flex flex-col flex-shrink-0 border-r border-gray-200 time-column">
+                <div className="flex-1">
+                  {hours.map((hour) => (
+                    <div
+                      key={hour}
+                      className="flex items-start justify-end pr-1 text-xs text-gray-500 border-b border-gray-100 transition-all duration-300"
+                      style={{ height: `${dynamicHourHeight}px` }}
+                    >
+                      {hour.toString().padStart(2, '0')}
+                    </div>
+                  ))}
+                </div>
               </div>
 
-              {/* Calendar Content Grid */}
-              <div
-                className="grid"
-                style={{ gridTemplateColumns: gridColumns }}
-                onClick={(e) => {
-                  const target = e.target as HTMLElement
-                  const isEmptySpace = !target.closest('[data-course-card]')
+              {/* Day columns with clean time-based rendering */}
+              {days.map((day) => {
+                // Get the CalendarEvent.day index for this day key
+                const calendarEventDayIndex = getDayIndex(day)
+                const dayEvents = events
+                  .filter((event) => event.day === calendarEventDayIndex)
+                  .map((event) => ({
+                    ...event,
+                    hasConflict: events.some(
+                      (other) =>
+                        other.id !== event.id &&
+                        other.day === event.day &&
+                        eventsOverlap(event, other)
+                    ),
+                  }))
 
-                  if (isEmptySpace && onSelectEnrollment) {
-                    onSelectEnrollment(null)
-                  }
-                }}
-              >
-                {/* Time column */}
-                <div className="flex flex-col flex-shrink-0 border-r border-gray-200 time-column">
-                  <div className="flex-1">
-                    {hours.map((hour) => (
-                      <div
-                        key={hour}
-                        className="flex items-start justify-end pr-1 text-xs text-gray-500 border-b border-gray-100 transition-all duration-300"
-                        style={{ height: `${dynamicHourHeight}px` }}
-                      >
-                        {hour.toString().padStart(2, '0')}
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                const eventGroups = groupOverlappingEvents(dayEvents)
 
-                {/* Day columns with clean time-based rendering */}
-                {days.map((day) => {
-                  // Get the CalendarEvent.day index for this day key
-                  const calendarEventDayIndex = getDayIndex(day)
-                  const dayEvents = events
-                    .filter((event) => event.day === calendarEventDayIndex)
-                    .map((event) => ({
-                      ...event,
-                      hasConflict: events.some(
-                        (other) =>
-                          other.id !== event.id &&
-                          other.day === event.day &&
-                          eventsOverlap(event, other)
-                      ),
-                    }))
+                return (
+                  <div
+                    key={day}
+                    className="flex flex-col relative min-w-0 flex-1 border-r border-gray-200 day-column"
+                  >
+                    {/* Hour slots with dynamic height */}
+                    <div className="relative flex-1">
+                      {hours.map((hour) => (
+                        <div
+                          key={hour}
+                          className="border-b border-gray-200 transition-all duration-300"
+                          style={{ height: `${dynamicHourHeight}px` }}
+                        />
+                      ))}
 
-                  const eventGroups = groupOverlappingEvents(dayEvents)
+                      {/* Dynamic conflict zones - scale with hour height */}
+                      {eventGroups.map((group, groupIndex) => {
+                        if (group.length <= 1) return null
 
-                  return (
-                    <div
-                      key={day}
-                      className="flex flex-col relative min-w-0 flex-1 border-r border-gray-200 day-column"
-                    >
-                      {/* Hour slots with dynamic height */}
-                      <div className="relative flex-1">
-                        {hours.map((hour) => (
+                        // Calculate based on pure time bounds with dynamic height
+                        const startTimes = group.map((e) => e.startHour * 60 + e.startMinute)
+                        const endTimes = group.map((e) => e.endHour * 60 + e.endMinute)
+                        const minStart = Math.min(...startTimes)
+                        const maxEnd = Math.max(...endTimes)
+
+                        const zoneTop =
+                          timeToPixels(
+                            Math.floor(minStart / 60),
+                            minStart % 60,
+                            calendarConfig.startHour,
+                            dynamicHourHeight
+                          ) - CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING
+                        const zoneBottom =
+                          timeToPixels(
+                            Math.floor(maxEnd / 60),
+                            maxEnd % 60,
+                            calendarConfig.startHour,
+                            dynamicHourHeight
+                          ) + CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING
+
+                        return (
                           <div
-                            key={hour}
-                            className="border-b border-gray-200 transition-all duration-300"
-                            style={{ height: `${dynamicHourHeight}px` }}
+                            key={`conflict-zone-${groupIndex}`}
+                            style={{
+                              position: 'absolute',
+                              top: `${zoneTop}px`,
+                              height: `${zoneBottom - zoneTop}px`,
+                              left: '0px',
+                              right: '0px',
+                              zIndex: 1,
+                              background:
+                                'repeating-linear-gradient(45deg, rgba(168, 85, 247, 0.6) 0px, rgba(168, 85, 247, 0.6) 10px, rgba(255, 255, 255, 0.3) 10px, rgba(255, 255, 255, 0.3) 20px)',
+                            }}
+                            className="border-2 border-purple-500 rounded-sm animate-pulse transition-all duration-300"
                           />
-                        ))}
+                        )
+                      })}
 
-                        {/* Dynamic conflict zones - scale with hour height */}
-                        {eventGroups.map((group, groupIndex) => {
-                          if (group.length <= 1) return null
+                      {/* Event cards with dynamic time-based positioning */}
+                      {eventGroups.map((group) => {
+                        return group.map((event, stackIndex) => {
+                          const { top, height } = getCardDimensions(
+                            event,
+                            calendarConfig.startHour,
+                            dynamicHourHeight
+                          )
+                          const isConflicted = group.length > 1
+                          const isSelected = selectedEnrollment === event.enrollmentId
 
-                          // Calculate based on pure time bounds with dynamic height
-                          const startTimes = group.map((e) => e.startHour * 60 + e.startMinute)
-                          const endTimes = group.map((e) => e.endHour * 60 + e.endMinute)
-                          const minStart = Math.min(...startTimes)
-                          const maxEnd = Math.max(...endTimes)
+                          // Stacking for conflicts
+                          const stackOffset = isConflicted
+                            ? stackIndex * CALENDAR_LAYOUT_CONSTANTS.CONFLICT_CARD_STACK_OFFSET
+                            : 0
+                          const rightOffset = isConflicted
+                            ? (group.length - 1 - stackIndex) *
+                              CALENDAR_LAYOUT_CONSTANTS.CONFLICT_CARD_STACK_OFFSET
+                            : 0
 
-                          const zoneTop =
-                            timeToPixels(
-                              Math.floor(minStart / 60),
-                              minStart % 60,
-                              calendarConfig.startHour,
-                              dynamicHourHeight
-                            ) - CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING
-                          const zoneBottom =
-                            timeToPixels(
-                              Math.floor(maxEnd / 60),
-                              maxEnd % 60,
-                              calendarConfig.startHour,
-                              dynamicHourHeight
-                            ) + CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING
+                          // Z-index should be lower than sticky header (z-50)
+                          let zIndex = isConflicted ? 20 + stackIndex : 10
+                          if (isSelected) zIndex = 40 // Lower than header z-50
 
                           return (
                             <div
-                              key={`conflict-zone-${groupIndex}`}
+                              key={event.id}
+                              ref={(el) => {
+                                if (el && event.enrollmentId) {
+                                  eventRefs.current.set(event.enrollmentId, el)
+                                } else if (event.enrollmentId) {
+                                  eventRefs.current.delete(event.enrollmentId)
+                                }
+                              }}
+                              data-course-card="true"
                               style={{
                                 position: 'absolute',
-                                top: `${zoneTop}px`,
-                                height: `${zoneBottom - zoneTop}px`,
-                                left: '0px',
-                                right: '0px',
-                                zIndex: 1,
-                                background:
-                                  'repeating-linear-gradient(45deg, rgba(168, 85, 247, 0.6) 0px, rgba(168, 85, 247, 0.6) 10px, rgba(255, 255, 255, 0.3) 10px, rgba(255, 255, 255, 0.3) 20px)',
-                              }}
-                              className="border-2 border-purple-500 rounded-sm animate-pulse transition-all duration-300"
-                            />
-                          )
-                        })}
-
-                        {/* Event cards with dynamic time-based positioning */}
-                        {eventGroups.map((group) => {
-                          return group.map((event, stackIndex) => {
-                            const { top, height } = getCardDimensions(
-                              event,
-                              calendarConfig.startHour,
-                              dynamicHourHeight
-                            )
-                            const isConflicted = group.length > 1
-                            const isSelected = selectedEnrollment === event.enrollmentId
-
-                            // Stacking for conflicts
-                            const stackOffset = isConflicted
-                              ? stackIndex * CALENDAR_LAYOUT_CONSTANTS.CONFLICT_CARD_STACK_OFFSET
-                              : 0
-                            const rightOffset = isConflicted
-                              ? (group.length - 1 - stackIndex) *
-                                CALENDAR_LAYOUT_CONSTANTS.CONFLICT_CARD_STACK_OFFSET
-                              : 0
-
-                            // Z-index should be lower than sticky header (z-50)
-                            let zIndex = isConflicted ? 20 + stackIndex : 10
-                            if (isSelected) zIndex = 40 // Lower than header z-50
-
-                            return (
-                              <div
-                                key={event.id}
-                                ref={(el) => {
-                                  if (el && event.enrollmentId) {
-                                    eventRefs.current.set(event.enrollmentId, el)
-                                  } else if (event.enrollmentId) {
-                                    eventRefs.current.delete(event.enrollmentId)
-                                  }
-                                }}
-                                data-course-card="true"
-                                style={{
-                                  position: 'absolute',
-                                  top: `${top}px`,
-                                  height: `${height}px`,
-                                  left: `${CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING + stackOffset}px`,
-                                  right: `${CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING + rightOffset}px`,
-                                  padding: `${CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING}px`,
-                                  zIndex,
-                                  ...(isSelected && {
-                                    backgroundImage: `repeating-linear-gradient(
+                                top: `${top}px`,
+                                height: `${height}px`,
+                                left: `${CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING + stackOffset}px`,
+                                right: `${CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING + rightOffset}px`,
+                                padding: `${CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING}px`,
+                                zIndex,
+                                ...(isSelected && {
+                                  backgroundImage: `repeating-linear-gradient(
                                   45deg,
                                   transparent,
                                   transparent 8px,
                                   rgba(255,255,255,0.15) 8px,
                                   rgba(255,255,255,0.15) 10px
                                 )`,
-                                  }),
-                                }}
-                                className={`
+                                }),
+                              }}
+                              className={`
                               ${event.color}
                               rounded-sm text-xs text-white
                               hover:scale-105 transition-all duration-300 cursor-pointer
                               overflow-hidden group
                               ${isSelected ? 'scale-105' : ''}
                             `}
-                                onClick={() => {
+                              onClick={() => {
+                                if (onSelectEnrollment && event.enrollmentId) {
+                                  const newSelection = isSelected ? null : event.enrollmentId
+                                  onSelectEnrollment(newSelection)
+                                }
+                              }}
+                            >
+                              {/* Visibility toggle button */}
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={(e) => {
+                                  e.stopPropagation()
                                   if (onSelectEnrollment && event.enrollmentId) {
-                                    const newSelection = isSelected ? null : event.enrollmentId
-                                    onSelectEnrollment(newSelection)
+                                    onSelectEnrollment(event.enrollmentId)
+                                  }
+                                  if (onToggleVisibility && event.enrollmentId) {
+                                    onToggleVisibility(event.enrollmentId)
                                   }
                                 }}
+                                className="absolute top-0.5 right-0.5 h-4 w-4 p-0 bg-black/20 hover:bg-white/40 backdrop-blur-sm cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                                title={event.isVisible ? 'Hide course' : 'Show course'}
                               >
-                                {/* Visibility toggle button */}
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    if (onSelectEnrollment && event.enrollmentId) {
-                                      onSelectEnrollment(event.enrollmentId)
-                                    }
-                                    if (onToggleVisibility && event.enrollmentId) {
-                                      onToggleVisibility(event.enrollmentId)
-                                    }
-                                  }}
-                                  className="absolute top-0.5 right-0.5 h-4 w-4 p-0 bg-black/20 hover:bg-white/40 backdrop-blur-sm cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity duration-200"
-                                  title={event.isVisible ? 'Hide course' : 'Show course'}
-                                >
-                                  {event.isVisible ? (
-                                    <Eye className="w-2.5 h-2.5 text-white" />
-                                  ) : (
-                                    <EyeOff className="w-2.5 h-2.5 text-white" />
-                                  )}
-                                </Button>
-
-                                {/* Course content with conditional rendering based on config */}
-                                <div className={`${TEXT_STYLES.COURSE_CODE} truncate pr-3`}>
-                                  {formatCourseCodeWithSection(
-                                    event.subject,
-                                    event.courseCode,
-                                    event.sectionCode
-                                  )}
-                                </div>
-
-                                {localDisplayConfig.showTitle && (
-                                  <div className={`${TEXT_STYLES.TITLE} truncate`}>
-                                    {event.title || 'Course Title'}
-                                  </div>
+                                {event.isVisible ? (
+                                  <Eye className="w-2.5 h-2.5 text-white" />
+                                ) : (
+                                  <EyeOff className="w-2.5 h-2.5 text-white" />
                                 )}
+                              </Button>
 
-                                {localDisplayConfig.showTime && (
-                                  <div className={`${TEXT_STYLES.TIME} truncate`}>
-                                    {formatTimeCompact(event.time)}
-                                  </div>
-                                )}
-
-                                {localDisplayConfig.showLocation && (
-                                  <div className={`${TEXT_STYLES.LOCATION} truncate`}>
-                                    {event.location}
-                                  </div>
-                                )}
-
-                                {localDisplayConfig.showInstructor && (
-                                  <div className={`${TEXT_STYLES.INSTRUCTOR} truncate`}>
-                                    {event.instructors
-                                      ? formatInstructorsCompact(event.instructors)
-                                      : 'TBA'}
-                                  </div>
+                              {/* Course content with conditional rendering based on config */}
+                              <div className={`${TEXT_STYLES.COURSE_CODE} truncate pr-3`}>
+                                {formatCourseCodeWithSection(
+                                  event.subject,
+                                  event.courseCode,
+                                  event.sectionCode
                                 )}
                               </div>
-                            )
-                          })
-                        })}
-                      </div>
+
+                              {localDisplayConfig.showTitle && (
+                                <div className={`${TEXT_STYLES.TITLE} truncate`}>
+                                  {event.title || 'Course Title'}
+                                </div>
+                              )}
+
+                              {localDisplayConfig.showTime && (
+                                <div className={`${TEXT_STYLES.TIME} truncate`}>
+                                  {formatTimeCompact(event.time)}
+                                </div>
+                              )}
+
+                              {localDisplayConfig.showLocation && (
+                                <div className={`${TEXT_STYLES.LOCATION} truncate`}>
+                                  {event.location}
+                                </div>
+                              )}
+
+                              {localDisplayConfig.showInstructor && (
+                                <div className={`${TEXT_STYLES.INSTRUCTOR} truncate`}>
+                                  {event.instructors
+                                    ? formatInstructorsCompact(event.instructors)
+                                    : 'TBA'}
+                                </div>
+                              )}
+                            </div>
+                          )
+                        })
+                      })}
                     </div>
-                  )
-                })}
-              </div>
+                  </div>
+                )
+              })}
             </div>
           </div>
         </div>

--- a/web/src/lib/calendarConfig.test.ts
+++ b/web/src/lib/calendarConfig.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { getGridColumns, getMinimumCalendarWidth } from './calendarConfig'
+
+describe('calendar column sizing', () => {
+  it('uses equal day columns with a minimum width', () => {
+    expect(getGridColumns(5)).toBe('48px repeat(5, minmax(128px, 1fr))')
+    expect(getGridColumns(7)).toBe('48px repeat(7, minmax(128px, 1fr))')
+  })
+
+  it('calculates when the calendar should start scrolling', () => {
+    expect(getMinimumCalendarWidth(5)).toBe(688)
+    expect(getMinimumCalendarWidth(7)).toBe(944)
+  })
+})

--- a/web/src/lib/calendarConfig.test.ts
+++ b/web/src/lib/calendarConfig.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { getGridColumns, getMinimumCalendarWidth } from './calendarConfig'
+import {
+  calculateReferenceCardHeight,
+  getCardTextLineLimits,
+  getGridColumns,
+  getMinimumCalendarWidth,
+  ROW_HEIGHTS,
+  type CalendarDisplayConfig,
+} from './calendarConfig'
+
+const displayConfig: CalendarDisplayConfig = {
+  showTitle: false,
+  showTime: true,
+  showLocation: true,
+  showInstructor: true,
+}
 
 describe('calendar column sizing', () => {
   it('uses equal day columns with a minimum width', () => {
@@ -10,5 +24,42 @@ describe('calendar column sizing', () => {
   it('calculates when the calendar should start scrolling', () => {
     expect(getMinimumCalendarWidth(5)).toBe(688)
     expect(getMinimumCalendarWidth(7)).toBe(944)
+  })
+})
+
+describe('calendar card text wrapping', () => {
+  const referenceHeight = calculateReferenceCardHeight(displayConfig)
+
+  it('keeps every field to one line when the card has no spare height', () => {
+    expect(getCardTextLineLimits(referenceHeight, displayConfig)).toEqual({
+      location: 1,
+      instructor: 1,
+    })
+  })
+
+  it('gives spare height to location before instructor', () => {
+    expect(getCardTextLineLimits(referenceHeight + ROW_HEIGHTS.LOCATION, displayConfig)).toEqual({
+      location: 2,
+      instructor: 1,
+    })
+  })
+
+  it('allows both fields to wrap when both extra lines fit', () => {
+    expect(
+      getCardTextLineLimits(
+        referenceHeight + ROW_HEIGHTS.LOCATION + ROW_HEIGHTS.INSTRUCTOR,
+        displayConfig
+      )
+    ).toEqual({ location: 2, instructor: 2 })
+  })
+
+  it('uses the first extra line for instructor when location is hidden', () => {
+    const instructorOnly = { ...displayConfig, showLocation: false }
+    const height = calculateReferenceCardHeight(instructorOnly) + ROW_HEIGHTS.INSTRUCTOR
+
+    expect(getCardTextLineLimits(height, instructorOnly)).toEqual({
+      location: 1,
+      instructor: 2,
+    })
   })
 })

--- a/web/src/lib/calendarConfig.ts
+++ b/web/src/lib/calendarConfig.ts
@@ -79,14 +79,14 @@ export const CALENDAR_LAYOUT_CONSTANTS = {
   BASE_HOUR_SLOT_HEIGHT: 64,
   /** Width of the time labels column displaying hours (e.g., "09", "10", "11") */
   TIME_LABEL_COLUMN_WIDTH: 48,
+  /** Smallest allowed day-column width */
+  MINIMUM_DAY_COLUMN_WIDTH: 128,
   /** Pixel offset for stacking overlapping course cards to show conflicts */
   CONFLICT_CARD_STACK_OFFSET: 16,
   /** Internal padding inside each course card for text spacing */
   COURSE_CARD_PADDING: 4,
   /** Absolute minimum height for very short events (accessibility requirement) */
   MINIMUM_CARD_HEIGHT: 24,
-  /** Minimum calendar width for proper display on smaller screens */
-  MINIMUM_CALENDAR_WIDTH: 640,
   /** Height of sticky header for scroll calculations */
   STICKY_HEADER_HEIGHT: 32,
 } as const
@@ -185,14 +185,16 @@ export function getRequiredDays(events: Array<{ day: number }>): WeekDay[] {
   return hasWeekendCourses(events) ? DAY_COMBINATIONS.full : DAY_COMBINATIONS.weekdays
 }
 
-/**
- * Generate CSS grid-template-columns string for calendar layout.
- * Creates responsive column layout: fixed time column + equal day columns.
- */
+/** Build equal day columns that stop shrinking at their minimum width. */
 export function getGridColumns(dayCount: number): string {
-  const timeColumnWidth = CALENDAR_LAYOUT_CONSTANTS.TIME_LABEL_COLUMN_WIDTH
-  const dayColumns = Array(dayCount).fill('1fr').join(' ')
-  return `${timeColumnWidth}px ${dayColumns}`
+  const { TIME_LABEL_COLUMN_WIDTH, MINIMUM_DAY_COLUMN_WIDTH } = CALENDAR_LAYOUT_CONSTANTS
+  return `${TIME_LABEL_COLUMN_WIDTH}px repeat(${dayCount}, minmax(${MINIMUM_DAY_COLUMN_WIDTH}px, 1fr))`
+}
+
+/** Calculate the width where the timetable starts scrolling. */
+export function getMinimumCalendarWidth(dayCount: number): number {
+  const { TIME_LABEL_COLUMN_WIDTH, MINIMUM_DAY_COLUMN_WIDTH } = CALENDAR_LAYOUT_CONSTANTS
+  return TIME_LABEL_COLUMN_WIDTH + dayCount * MINIMUM_DAY_COLUMN_WIDTH
 }
 
 /** Get calendar configuration with weekend support */

--- a/web/src/lib/calendarConfig.ts
+++ b/web/src/lib/calendarConfig.ts
@@ -132,6 +132,38 @@ export const ROW_HEIGHTS = {
  */
 export const MINIMUM_COURSE_DURATION_MINUTES = 45
 
+export function calculateReferenceCardHeight(displayConfig: CalendarDisplayConfig): number {
+  let height = ROW_HEIGHTS.COURSE_CODE
+
+  if (displayConfig.showTitle) height += ROW_HEIGHTS.TITLE
+  if (displayConfig.showTime) height += ROW_HEIGHTS.TIME
+  if (displayConfig.showLocation) height += ROW_HEIGHTS.LOCATION
+  if (displayConfig.showInstructor) height += ROW_HEIGHTS.INSTRUCTOR
+
+  return height + CALENDAR_LAYOUT_CONSTANTS.COURSE_CARD_PADDING * 2
+}
+
+/** Spend spare duration-derived height on at most one extra line per field. */
+export function getCardTextLineLimits(
+  cardHeight: number,
+  displayConfig: CalendarDisplayConfig
+): { location: 1 | 2; instructor: 1 | 2 } {
+  let spareHeight = Math.max(0, cardHeight - calculateReferenceCardHeight(displayConfig))
+  let location: 1 | 2 = 1
+  let instructor: 1 | 2 = 1
+
+  if (displayConfig.showLocation && spareHeight >= ROW_HEIGHTS.LOCATION) {
+    location = 2
+    spareHeight -= ROW_HEIGHTS.LOCATION
+  }
+
+  if (displayConfig.showInstructor && spareHeight >= ROW_HEIGHTS.INSTRUCTOR) {
+    instructor = 2
+  }
+
+  return { location, instructor }
+}
+
 // Default calendar configuration
 export const DEFAULT_CALENDAR_CONFIG: CalendarLayoutConfig = {
   activeDays: DAY_COMBINATIONS.weekdays,

--- a/web/src/lib/screenshotUtils.test.ts
+++ b/web/src/lib/screenshotUtils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getScreenshotContentWidth } from './screenshotUtils'
+
+describe('screenshot content width', () => {
+  it('uses the screenshot floor for a five-day calendar', () => {
+    expect(getScreenshotContentWidth(688)).toBe(800)
+  })
+
+  it('keeps a wider seven-day calendar at its minimum width', () => {
+    expect(getScreenshotContentWidth(944)).toBe(944)
+  })
+})

--- a/web/src/lib/screenshotUtils.test.ts
+++ b/web/src/lib/screenshotUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getScreenshotContentWidth } from './screenshotUtils'
+import { getScreenshotCaptureHeight, getScreenshotContentWidth } from './screenshotUtils'
 
 describe('screenshot content width', () => {
   it('uses the screenshot floor for a five-day calendar', () => {
@@ -8,5 +8,11 @@ describe('screenshot content width', () => {
 
   it('keeps a wider seven-day calendar at its minimum width', () => {
     expect(getScreenshotContentWidth(944)).toBe(944)
+  })
+})
+
+describe('screenshot capture height', () => {
+  it('keeps the timetable bottom edge inside the capture area', () => {
+    expect(getScreenshotCaptureHeight(640)).toBe(641)
   })
 })

--- a/web/src/lib/screenshotUtils.ts
+++ b/web/src/lib/screenshotUtils.ts
@@ -3,6 +3,8 @@
  * Extracted from courseUtils.ts for better separation of concerns
  */
 
+import { CALENDAR_LAYOUT_CONSTANTS } from './calendarConfig'
+
 // Centralized screenshot configuration
 const SCREENSHOT_CONFIG = {
   // DOM element selectors
@@ -46,17 +48,14 @@ const SCREENSHOT_CONFIG = {
   // Element styling during preparation
   styling: {
     unscheduledContainer: {
-      paddingRight: '32px',
       paddingBottom: '24px',
-      marginLeft: '30px', // Align with calendar time column
-      marginRight: '16px',
       marginBottom: '16px',
     },
     courseCard: {
       maxWidth: '160px',
       minWidth: '140px',
     },
-    minElementWidth: 800,
+    minContentWidth: 800,
   },
 
   // CSS class replacements for clean screenshots
@@ -65,6 +64,15 @@ const SCREENSHOT_CONFIG = {
     'shadow-lg': 'shadow-sm',
   },
 } as const
+
+export function getScreenshotContentWidth(minimumCalendarWidth: number): number {
+  return Math.max(minimumCalendarWidth, SCREENSHOT_CONFIG.styling.minContentWidth)
+}
+
+interface CalendarScreenshotOptions {
+  minimumCalendarWidth: number
+  websiteUrl?: string
+}
 
 // Layout configuration interface
 interface LayoutConfig {
@@ -277,11 +285,19 @@ class ScreenshotStateManager {
  * Prepare calendar element for screenshot capture
  * Handles basic visibility and sizing requirements
  */
-function prepareCalendarElement(element: HTMLElement, stateManager: ScreenshotStateManager): void {
+function prepareCalendarElement(
+  element: HTMLElement,
+  stateManager: ScreenshotStateManager,
+  captureWidth: number
+): void {
   const originalStyle = element.style.cssText
   stateManager.storeElementState(element, originalStyle)
 
   // Expand element for capture
+  element.style.width = `${captureWidth}px`
+  element.style.minWidth = `${captureWidth}px`
+  element.style.maxWidth = `${captureWidth}px`
+  element.style.boxSizing = 'border-box'
   element.style.maxHeight = 'none'
   element.style.height = 'auto'
   element.style.overflow = 'visible'
@@ -314,25 +330,18 @@ function findSelectedCards(element: HTMLElement): NodeListOf<Element> {
 /**
  * Apply unscheduled container styling using configuration
  */
-function applyUnscheduledContainerStyling(container: HTMLElement, calendarWidth?: number): void {
+function applyUnscheduledContainerStyling(container: HTMLElement, captureWidth: number): void {
   const styling = SCREENSHOT_CONFIG.styling.unscheduledContainer
 
   // Transform from card to distinct section with proper borders
   container.setAttribute('class', 'border border-gray-200 bg-white')
 
-  // Apply configured margins
-  container.style.marginLeft = styling.marginLeft
-  container.style.marginRight = styling.marginRight
+  const leftInset = CALENDAR_LAYOUT_CONSTANTS.TIME_LABEL_COLUMN_WIDTH
+  container.style.marginLeft = `${leftInset}px`
+  container.style.marginRight = '0'
   container.style.marginBottom = styling.marginBottom
   container.style.boxSizing = 'border-box'
-
-  // Set width based on calendar width if provided
-  if (calendarWidth) {
-    const marginLeft = parseInt(styling.marginLeft)
-    const marginRight = parseInt(styling.marginRight)
-    const availableWidth = calendarWidth - marginLeft - marginRight
-    container.style.width = `${availableWidth}px`
-  }
+  container.style.width = `${captureWidth - leftInset}px`
 }
 
 /**
@@ -361,7 +370,7 @@ function applyCourseCardStyling(
 function prepareUnscheduledElement(
   element: HTMLElement,
   stateManager: ScreenshotStateManager,
-  calendarWidth?: number
+  captureWidth: number
 ): void {
   const originalStyle = element.style.cssText
   stateManager.storeElementState(element, originalStyle)
@@ -369,12 +378,14 @@ function prepareUnscheduledElement(
   const containerStyling = SCREENSHOT_CONFIG.styling.unscheduledContainer
 
   // Container sizing and overflow
-  element.style.paddingRight = containerStyling.paddingRight
+  element.style.paddingLeft = '0'
+  element.style.paddingRight = '0'
   element.style.paddingBottom = containerStyling.paddingBottom
-  element.style.width = 'auto'
-  element.style.minWidth = '100%'
+  element.style.width = `${captureWidth}px`
+  element.style.minWidth = `${captureWidth}px`
+  element.style.maxWidth = `${captureWidth}px`
   element.style.overflow = 'visible'
-  element.style.boxSizing = 'content-box'
+  element.style.boxSizing = 'border-box'
   element.style.maxHeight = 'none'
   element.style.height = 'auto'
   element.style.overflowY = 'visible'
@@ -391,7 +402,7 @@ function prepareUnscheduledElement(
       [{ element: cardContainer, originalClass }]
     )
 
-    applyUnscheduledContainerStyling(cardContainer, calendarWidth)
+    applyUnscheduledContainerStyling(cardContainer, captureWidth)
   }
 
   // Hide interactive elements for professional look
@@ -596,29 +607,25 @@ function downloadCompositeImage(canvas: HTMLCanvasElement, termName: string): Pr
   })
 }
 
-/**
- * Captures a calendar screenshot with term name header and website attribution
- * Now supports compositing calendar and unscheduled sections together
- */
+/** Capture and download the timetable with optional unscheduled courses. */
 export async function captureCalendarScreenshot(
   calendarElement: HTMLElement,
   unscheduledElement: HTMLElement | null,
   termName: string,
-  websiteUrl: string = typeof window !== 'undefined' ? window.location.origin : ''
+  options: CalendarScreenshotOptions
 ): Promise<void> {
   const stateManager = new ScreenshotStateManager()
+  const captureWidth = getScreenshotContentWidth(options.minimumCalendarWidth)
+  const websiteUrl =
+    options.websiteUrl ?? (typeof window !== 'undefined' ? window.location.origin : '')
 
   try {
     // Helper to prepare element for screenshot capture with measurements
-    const prepareElementForCapture = async (
-      element: HTMLElement,
-      isUnscheduled = false,
-      calendarWidth?: number
-    ) => {
+    const prepareElementForCapture = async (element: HTMLElement, isUnscheduled = false) => {
       if (isUnscheduled) {
-        prepareUnscheduledElement(element, stateManager, calendarWidth)
+        prepareUnscheduledElement(element, stateManager, captureWidth)
       } else {
-        prepareCalendarElement(element, stateManager)
+        prepareCalendarElement(element, stateManager, captureWidth)
       }
 
       // Force layout recalculation
@@ -628,7 +635,7 @@ export async function captureCalendarScreenshot(
       const rect = element.getBoundingClientRect()
       return {
         element,
-        actualWidth: Math.max(rect.width, SCREENSHOT_CONFIG.styling.minElementWidth),
+        actualWidth: rect.width,
         actualHeight: rect.height,
       }
     }
@@ -643,13 +650,7 @@ export async function captureCalendarScreenshot(
       actualHeight: number
     } | null = null
     if (unscheduledElement) {
-      unscheduledInfo = await prepareElementForCapture(
-        unscheduledElement,
-        true,
-        calendarInfo.actualWidth
-      )
-      // Match width to calendar for perfect alignment
-      unscheduledInfo.actualWidth = calendarInfo.actualWidth
+      unscheduledInfo = await prepareElementForCapture(unscheduledElement, true)
     }
 
     // Step 2.5: Clear selection visual effects for clean screenshot (CSS only)

--- a/web/src/lib/screenshotUtils.ts
+++ b/web/src/lib/screenshotUtils.ts
@@ -69,6 +69,10 @@ export function getScreenshotContentWidth(minimumCalendarWidth: number): number 
   return Math.max(minimumCalendarWidth, SCREENSHOT_CONFIG.styling.minContentWidth)
 }
 
+export function getScreenshotCaptureHeight(measuredHeight: number): number {
+  return Math.ceil(measuredHeight) + 1
+}
+
 interface CalendarScreenshotOptions {
   minimumCalendarWidth: number
   websiteUrl?: string
@@ -636,7 +640,7 @@ export async function captureCalendarScreenshot(
       return {
         element,
         actualWidth: rect.width,
-        actualHeight: rect.height,
+        actualHeight: isUnscheduled ? rect.height : getScreenshotCaptureHeight(rect.height),
       }
     }
 


### PR DESCRIPTION
- wrapping into 2 lines on the location if needed (not applicable for 45-minute meeting, as this is just a minor improvement; for 45-min meeting would need to increase the height of the meeting card conditionally #68 

Before
<img width="155" height="112" alt="image" src="https://github.com/user-attachments/assets/581c3232-4bd5-42cb-9f74-bab24cb1a10b" />
After
<img width="158" height="113" alt="image" src="https://github.com/user-attachments/assets/43788cbe-2734-4576-aa08-6368d34d2b47" />

---

- better width handling on devices with smaller widths
- consistent (full) width for both mobile & desktop

Before (screenshot on small screen)
<img width="646" height="162" alt="image" src="https://github.com/user-attachments/assets/1b3aa019-b974-4273-8f5a-048931271f35" />
After (screenshot on small screen)
<img width="609" height="277" alt="image" src="https://github.com/user-attachments/assets/3301080b-eedb-4973-bfaf-ae202bc0bc91" />

