### PR TITLE
docs: point deferred refactors at their open issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,4 @@ Run checks proportional to the change. Avoid full scrapes or full builds unless 
 
 `TODO(#N):` marks deferred work with a filed issue; a bare `TODO:` is an unfiled note. When editing near one, mention it, and propose the fix if it is small or blocking — as its own commit, never folded into the current diff. Don't act unasked.
 
-Remove the marker when closing its issue (`grep -rn "#N"`). Pointers to closed issues train readers to ignore markers.
+Remove the marker when closing its issue (grep for its number). Pointers to closed issues train readers to ignore markers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,7 @@ When writing or editing docs, verify each claim against the current implementati
 When changing code, check whether a doc in `docs/` describes the affected behavior and update it in the same change.
 
 Run checks proportional to the change. Avoid full scrapes or full builds unless they are relevant, requested, or needed.
+
+`TODO(#N):` marks deferred work with a filed issue; a bare `TODO:` is an unfiled note. When editing near one, mention it, and propose the fix if it is small or blocking — as its own commit, never folded into the current diff. Don't act unasked.
+
+Remove the marker when closing its issue (`grep -rn "#N"`). Pointers to closed issues train readers to ignore markers.

--- a/docs/commit-conventions.md
+++ b/docs/commit-conventions.md
@@ -8,6 +8,8 @@ Use Conventional Commit titles with a small, project-specific set of types and s
 
 The scope is optional. Add `!` before `:` for a breaking change.
 
+Reference an issue with `Refs #N` in the body; it shows up on the issue timeline. Use `Closes #N` only when the commit really closes it — GitHub acts on that at merge.
+
 ## Types
 
 | Type       | Use for                                                     |

--- a/docs/commit-conventions.md
+++ b/docs/commit-conventions.md
@@ -8,7 +8,7 @@ Use Conventional Commit titles with a small, project-specific set of types and s
 
 The scope is optional. Add `!` before `:` for a breaking change.
 
-Reference an issue with `Refs #N` in the body; it shows up on the issue timeline. Use `Closes #N` only when the commit really closes it — GitHub acts on that at merge.
+Reference an issue with a `Refs: #N` trailer; it shows up on the issue timeline. Use `Closes #N` only when the commit really closes it — GitHub acts on that at merge.
 
 ## Types
 

--- a/docs/components/shopping-cart.md
+++ b/docs/components/shopping-cart.md
@@ -34,6 +34,8 @@ Transitions and acknowledgment:
 - The Review banner (`getChangedCourseIds`) queues unseen invalid reasons, unacknowledged visible tombstones, and section-detail changes. **Dismiss all** acknowledges only what is visible: tombstones hidden behind an invalid card stay unacknowledged, so they re-alert once the course returns and they can actually be seen.
 - Re-adding from search (`updateExistingEnrollment`) is the full reset: clears invalid state, tombstones, and acknowledgments, and refreshes the stale `course`.
 
+Acknowledgment runs on three mechanisms with separate reset rules (`lastSeenSections`, `lastSeenInvalidState`, `removedSectionsAcknowledged`). Unifying them into one snapshot is [#215](https://github.com/EagleZhen/another-cuhk-course-planner/issues/215).
+
 `isVisible` (the eye toggle) is orthogonal: a hidden course leaves the timetable and ICS but its lifecycle keeps running. See [architecture.md](../architecture.md#browser-state).
 
 ## Change Detection

--- a/scripts/cuhk_scraper.py
+++ b/scripts/cuhk_scraper.py
@@ -1204,8 +1204,7 @@ class CuhkScraper:
         desc_elem = soup.find("span", {"id": "uc_course_lbl_crse_descrlong"})
         if desc_elem:
             # Use HTML content (not extracted text) to preserve <br> tags and formatting
-            # TODO: Consider preserving original HTML and converting to markdown later for better robustness
-            # This would allow re-processing if conversion logic improves without re-scraping
+            # TODO(#27): store the original HTML too, so conversion can improve without re-scraping
             desc_html = str(desc_elem)
             course.description, _ = html_to_clean_markdown(desc_html)
 
@@ -1756,10 +1755,7 @@ class CuhkScraper:
 
     def _parse_course_outcome_content(self, html: str, course: Course) -> None:
         """Parse Course Outcome page content and extract all relevant information"""
-        # TODO: Consider preserving original HTML alongside markdown conversion
-        # This would allow re-processing with improved conversion logic without re-scraping
-        # Current approach: HTML → Markdown (one-way, conversion challenges with complex HTML)
-        # Future approach: Store both HTML and Markdown, convert HTML post-scraping
+        # TODO(#27): store the original HTML too, so conversion can improve without re-scraping
         soup = BeautifulSoup(html, "html.parser")
 
         # Extract Assessment Types (table structure)

--- a/scripts/cuhk_scraper.py
+++ b/scripts/cuhk_scraper.py
@@ -2030,6 +2030,10 @@ class CuhkScraper:
                 if os.path.exists(stale_no_terms):
                     os.remove(stale_no_terms)
 
+            # Year dirs get no equivalent pruning: a subject that drops out of a still-active
+            # year keeps its file from the previous scrape, and the app still serves it.
+            # TODO(#149): reconcile year subdirs the same way.
+
             summary = ", ".join(written) if written else "(no file — empty subject)"
             self.logger.info(f"💾 SAVED {subject} → {summary}")
             return written

--- a/scripts/data_utils.py
+++ b/scripts/data_utils.py
@@ -5,6 +5,9 @@ Designed to handle Word HTML artifacts and provide clean markdown conversion.
 
 Extracted from cuhk_scraper.py for maintainability and reusability.
 This module has no external dependencies beyond BeautifulSoup and optional markdownify.
+
+Despite the name, it also holds publish-side helpers: year/term partitioning and manifest generation.
+TODO(#153): split scrape vs. publish utilities.
 """
 
 import json

--- a/scripts/publish_course_data.py
+++ b/scripts/publish_course_data.py
@@ -388,6 +388,7 @@ class ConsoleLogger:
         self.log_file.close()
 
 
+# TODO(#154): extract each phase into a named helper so this reads as a sequence of steps
 def main():
     # Generate log filename with timestamp
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/web/functions/x8m2k/[[path]].ts
+++ b/web/functions/x8m2k/[[path]].ts
@@ -2,7 +2,8 @@
 // don't see PostHog's domain. Replaces the next.config rewrite (dropped under
 // output: 'export') and is our only Function; everything else is static.
 //
-// Single-host to match the old rewrite exactly; splitting the assets host is #177.
+// Single-host to match the old rewrite exactly.
+// TODO(#177): route /static/* to the assets host.
 
 interface Env {
   POSTHOG_HOST?: string // optional binding to override the region host

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -511,7 +511,8 @@ export default function Home() {
           console.debug(`Successfully synced ${syncedEnrollments.length} enrollments`)
         }
 
-        // Update sync timestamp after successful sync
+        // This setState and the logs above sit inside the updater, so StrictMode double-invokes them
+        // TODO(#172): move them out to an effect
         setLastSyncTimestamp(timestamp)
 
         return syncedEnrollments

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -58,6 +58,7 @@ export default function Home() {
   const [selectedSections, setSelectedSections] = useState<Map<string, string>>(new Map())
   const [selectedEnrollment, setSelectedEnrollment] = useState<string | null>(null)
   const [lastSyncTimestamp, setLastSyncTimestamp] = useState<Date | null>(null)
+  // TODO(#146): rename to reflect these are toggled subject filters, not selected subjects
   const [selectedSubjects, setSelectedSubjects] = useState<Set<string>>(new Set())
   const [availableSubjects, setAvailableSubjects] = useState<string[]>([])
   const [showSelectedOnly, setShowSelectedOnly] = useState<boolean>(false)

--- a/web/src/lib/courseUtils.ts
+++ b/web/src/lib/courseUtils.ts
@@ -1,5 +1,6 @@
 // Unified course utilities for conflict detection and data transformation
 // Uses clean internal types with proper validation boundaries
+// TODO(#159): split this grab-bag into focused modules
 
 import type {
   TimeRange,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -133,6 +133,9 @@ export interface InvalidEnrollmentState {
 }
 
 // Course enrollment using clean internal types
+// Acknowledgment is tracked by three separate mechanisms below: removedSectionsAcknowledged,
+// lastSeenSections, and lastSeenInvalidState
+// TODO(#215): unify them into one snapshot
 export interface CourseEnrollment {
   courseId: string
   course: InternalCourse // ✅ Strong internal type


### PR DESCRIPTION
Low-priority refactor issues never got picked up because the backlog is indexed issue → file, while at the moment they matter you have the file open and need file → issues. This puts a `TODO(#N)` marker at each one's anchor point, so the reminder shows up where the work happens.

Ten markers across six files, plus the convention in AGENTS.md. No behavior changes.

**Scope**

- Only issues anchored to existing code, expected to stay dormant, in files that actually churn. Features and P1/P2 items are excluded; marking everything would recreate the TODO-blindness that makes markers work.
- Anchor granularity matches issue scope: a line, a file header, or the one declaration everything passes through (#215 sits on `CourseEnrollment`).
- Existing markers normalized: the #177 prose comment, and the two duplicated #27 TODOs.

**Also**

- #27 and #146 issue bodies rewritten.
- #27 absorbed the design rationale deleted from its two code sites;
- #146 was narrowed from a general disposition to the one concrete rename, so the marker points at something actionable.
- `docs/commit-conventions.md` records the `Refs: #N` trailer, which is what surfaces these on each issue's timeline (GitHub doesn't index issue numbers in code comments).